### PR TITLE
refactor: remove `/api` from path

### DIFF
--- a/pol/api/v0/person.py
+++ b/pol/api/v0/person.py
@@ -22,7 +22,7 @@ from pol.curd.exceptions import NotFoundError
 
 router = APIRouter(tags=["人物"])
 
-api_base = "/api/v0/persons"
+api_base = "/v0/persons"
 
 
 async def basic_person(

--- a/pol/server.py
+++ b/pol/server.py
@@ -25,7 +25,7 @@ app = FastAPI(
 
 app.add_middleware(cors.CORSMiddleware, allow_origins=["bgm.tv", "bangumi.tv"])
 setup_http_middleware(app)
-app.include_router(api.router, prefix="/api")
+app.include_router(api.router)
 
 
 @app.exception_handler(res.HTTPException)
@@ -66,12 +66,12 @@ async def shutdown() -> None:
     await app.state.db.disconnect()
 
 
-@app.get("/openapi.json", include_in_schema=False)
+@app.get("/v0/openapi.json", include_in_schema=False)
 async def openapi():
     return app.openapi()
 
 
-@app.get("/", response_class=HTMLResponse, include_in_schema=False)
+@app.get("/v0", response_class=HTMLResponse, include_in_schema=False)
 async def doc():
     return """<!DOCTYPE html>
 <html lang=zh-cmn-Hans>
@@ -93,7 +93,7 @@ async def doc():
 </script>
 <script>
 const ui = SwaggerUIBundle({
-    url: '/openapi.json',
+    url: '/v0/openapi.json',
     dom_id: '#swagger-ui',
     presets: [
         SwaggerUIBundle.presets.apis,

--- a/tests/app/api_v0/test_person.py
+++ b/tests/app/api_v0/test_person.py
@@ -2,23 +2,23 @@ from starlette.testclient import TestClient
 
 
 def test_person_not_found(client: TestClient):
-    response = client.get("/api/v0/persons/2000000")
+    response = client.get("/v0/persons/2000000")
     assert response.status_code == 404
     assert response.headers["content-type"] == "application/json"
 
 
 def test_person_not_valid(client: TestClient):
-    response = client.get("/api/v0/persons/hello")
+    response = client.get("/v0/persons/hello")
     assert response.status_code == 422
     assert response.headers["content-type"] == "application/json"
 
-    response = client.get("/api/v0/persons/0")
+    response = client.get("/v0/persons/0")
     assert response.status_code == 422
     assert response.headers["content-type"] == "application/json"
 
 
 def test_person_basic(client: TestClient):
-    response = client.get("/api/v0/persons/2")
+    response = client.get("/v0/persons/2")
     assert response.status_code == 200
     assert response.headers["content-type"] == "application/json"
 
@@ -28,12 +28,12 @@ def test_person_basic(client: TestClient):
 
 
 def test_person_ban_404(client: TestClient):
-    response = client.get("/api/v0/persons/6")
+    response = client.get("/v0/persons/6")
     assert response.status_code == 404
 
 
 def test_person_subjects(client: TestClient):
-    response = client.get("/api/v0/persons/1/subjects")
+    response = client.get("/v0/persons/1/subjects")
     assert response.status_code == 200
 
     subjects = response.json()
@@ -47,12 +47,12 @@ def test_person_subjects(client: TestClient):
 
 
 def test_person_redirect(client: TestClient):
-    response = client.get("/api/v0/persons/10", allow_redirects=False)
+    response = client.get("/v0/persons/10", allow_redirects=False)
     assert response.status_code == 307
 
 
 def test_person_lock(client: TestClient):
-    response = client.get("/api/v0/persons/9")
+    response = client.get("/v0/persons/9")
     assert response.status_code == 200
     assert response.headers["content-type"] == "application/json"
 

--- a/tests/app/api_v0/test_persons.py
+++ b/tests/app/api_v0/test_persons.py
@@ -5,7 +5,7 @@ from pol.db.tables import ChiiPerson
 
 
 def test_persons_basic_router(client: TestClient):
-    response = client.get("/api/v0/persons")
+    response = client.get("/v0/persons")
     assert response.status_code == 200
     assert response.headers["content-type"] == "application/json"
 
@@ -17,7 +17,7 @@ def test_persons_basic_router(client: TestClient):
 
 def test_persons_filter_name(client: TestClient):
     name = "和田薫"
-    response = client.get("/api/v0/persons", params={"name": name})
+    response = client.get("/v0/persons", params={"name": name})
     assert response.status_code == 200
     assert response.headers["content-type"] == "application/json"
 
@@ -31,7 +31,7 @@ def test_persons_filter_name(client: TestClient):
 
 def test_persons_filter_career_valid(client: TestClient):
     career = "artist"
-    response = client.get("/api/v0/persons", params={"career": career})
+    response = client.get("/v0/persons", params={"career": career})
     assert response.status_code == 200
     res = response.json()
 
@@ -39,13 +39,13 @@ def test_persons_filter_career_valid(client: TestClient):
 
 
 def test_persons_filter_career_invalid(client: TestClient):
-    response = client.get("/api/v0/persons", params={"career": "e"})
+    response = client.get("/v0/persons", params={"career": "e"})
     assert response.status_code == 422
 
 
 def test_persons_page_limit(client: TestClient):
     limit = 3
-    response = client.get("/api/v0/persons", params={"limit": limit})
+    response = client.get("/v0/persons", params={"limit": limit})
     assert response.status_code == 200
 
     res = response.json()
@@ -54,14 +54,14 @@ def test_persons_page_limit(client: TestClient):
 
 def test_persons_page_limit_too_big(client: TestClient, db_session: Session):
     limit = 30000
-    response = client.get("/api/v0/persons", params={"limit": limit})
+    response = client.get("/v0/persons", params={"limit": limit})
     assert response.status_code == 422, response.text
 
 
 def test_persons_page_limit_big_omit(client: TestClient, db_session: Session):
     limit = 50
 
-    response = client.get("/api/v0/persons", params={"limit": limit})
+    response = client.get("/v0/persons", params={"limit": limit})
     assert response.status_code == 200, response.text
 
     res = response.json()
@@ -74,12 +74,12 @@ def test_persons_page_limit_big_omit(client: TestClient, db_session: Session):
 
 
 def test_persons_page_sort_invalid(client: TestClient, db_session: Session):
-    response = client.get("/api/v0/persons", params={"sort": "s"})
+    response = client.get("/v0/persons", params={"sort": "s"})
     assert response.status_code == 422, response.text
 
 
 def test_persons_page_offset(client: TestClient, db_session: Session):
-    response = client.get("/api/v0/persons", params={"offset": 1})
+    response = client.get("/v0/persons", params={"offset": 1})
     assert response.status_code == 200, response.text
 
     expected = [
@@ -96,7 +96,7 @@ def test_persons_page_offset(client: TestClient, db_session: Session):
 
 
 def test_persons_sort_valid(client: TestClient, db_session: Session):
-    response = client.get("/api/v0/persons", params={"sort": "id"})
+    response = client.get("/v0/persons", params={"sort": "id"})
     assert response.status_code == 200, response.text
 
     expected = [

--- a/tests/app/test_base_router.py
+++ b/tests/app/test_base_router.py
@@ -2,12 +2,12 @@ from starlette.testclient import TestClient
 
 
 def test_doc_html(client: TestClient):
-    response = client.get("/")
+    response = client.get("/v0")
     assert response.status_code == 200
     assert "text/html" in response.headers["content-type"]
 
 
 def test_openapi_json(client: TestClient):
-    response = client.get("/openapi.json")
+    response = client.get("/v0/openapi.json")
     assert response.status_code == 200
     assert response.headers["content-type"] == "application/json"


### PR DESCRIPTION
现在的服务器部属到了 `api.bgm.tv` 域名下，所以路径中的api就没有必要保留了