### PR TITLE
fix: plural in router

### DIFF
--- a/pol/api/v0/depends/__init__.py
+++ b/pol/api/v0/depends/__init__.py
@@ -1,5 +1,4 @@
-from fastapi import Depends
-from starlette.requests import Request
+from fastapi import Path, Depends
 
 from pol import res
 from pol.models import PublicUser
@@ -7,8 +6,7 @@ from pol.services.user_service import UserService
 
 
 async def get_public_user(
-    request: Request,
-    username: str,
+    username: str = Path(..., description="设置了 username 后无法使用UID"),
     user_service: UserService = Depends(UserService.new),
     not_found: res.HTTPException = Depends(res.not_found_exception),
 ) -> PublicUser:

--- a/pol/api/v0/user/collection.py
+++ b/pol/api/v0/user/collection.py
@@ -38,15 +38,20 @@ class UserCollection(BaseModel):
 
 
 @router.get(
-    "/user/{username}/collections",
+    "/users/{username}/collections",
     summary="获取用户收藏",
-    description="获取对应用户的收藏，查看私有收藏需要access token。\n设置了 username 的用户无法通过数字ID查询",
+    description="获取对应用户的收藏，查看私有收藏需要access token。",
     response_model=Paged[UserCollection],
     responses={
         404: res.response(model=ErrorDetail, description="用户不存在"),
     },
 )
-async def get_subject(
+@router.get(
+    "/user/{username}/collections",
+    include_in_schema=False,
+    response_model=Paged[UserCollection],
+)
+async def get_user_collection(
     user: Role = Depends(optional_user),
     page: Pager = Depends(),
     u: PublicUser = Depends(get_public_user),

--- a/tests/app/api_v0/test_collection.py
+++ b/tests/app/api_v0/test_collection.py
@@ -4,14 +4,14 @@ from tests.conftest import MockUser
 
 
 def test_collection_not_found(client: TestClient):
-    response = client.get("/v0/user/2000000/collections")
+    response = client.get("/v0/users/2000000/collections")
     assert response.status_code == 404
     assert response.headers["content-type"] == "application/json"
 
 
 def test_collection_public(client: TestClient, mock_user_collection):
     mock_user_collection(id=1, user_id=382951, subject_id=1, private=True)
-    response = client.get("/v0/user/382951/collections")
+    response = client.get("/v0/users/382951/collections")
     assert response.status_code == 200
     assert response.headers["content-type"] == "application/json"
 
@@ -20,7 +20,7 @@ def test_collection_public(client: TestClient, mock_user_collection):
 
 def test_collection_private(client: TestClient, auth_header, mock_user_collection):
     mock_user_collection(id=1, user_id=382951, subject_id=1, private=False)
-    response = client.get("/v0/user/382951/collections", headers=auth_header)
+    response = client.get("/v0/users/382951/collections", headers=auth_header)
     assert response.status_code == 200
     assert response.headers["content-type"] == "application/json"
 
@@ -35,7 +35,7 @@ def test_collection_username(
 ):
     mock_user(user_id=6, username="ua")
     mock_user_collection(id=1, user_id=6, subject_id=1, private=False)
-    response = client.get("/v0/user/ua/collections", headers=auth_header)
+    response = client.get("/v0/users/ua/collections", headers=auth_header)
     assert response.status_code == 200
     assert response.headers["content-type"] == "application/json"
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -124,7 +124,7 @@ class MockUser(Protocol):
         access_token: str = "",
         username: str = "",
         expires: datetime = datetime.now(),
-    ) -> None:  # pragma: no cover
+    ) -> None:
         pass
 
 
@@ -238,7 +238,11 @@ def mock_user(db_session: Session) -> Generator[MockUser, None, None]:
                 ChiiOauthAccessToken.access_token == access_token
             )
         delete_query[ChiiMember].append(ChiiMember.uid == user_id)
-        check_exist(db_session, delete_query)
+        try:
+            check_exist(db_session, delete_query)
+        except ValueError as e:
+            print(e)
+            return
 
         if access_token:
             db_session.add(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -124,7 +124,7 @@ class MockUser(Protocol):
         access_token: str = "",
         username: str = "",
         expires: datetime = datetime.now(),
-    ) -> None:
+    ) -> None:  # pragma: no cover
         pass
 
 
@@ -238,11 +238,7 @@ def mock_user(db_session: Session) -> Generator[MockUser, None, None]:
                 ChiiOauthAccessToken.access_token == access_token
             )
         delete_query[ChiiMember].append(ChiiMember.uid == user_id)
-        try:
-            check_exist(db_session, delete_query)
-        except ValueError as e:
-            print(e)
-            return
+        check_exist(db_session, delete_query)
 
         if access_token:
             db_session.add(


### PR DESCRIPTION
原本的路由写成了 `/user/{username}/collections`，现在改成了 `/users/{username}/collections`, 旧路由仅在文档中隐藏。