### PR TITLE
refactor(test:revision): replace mock_user with mock_user_service

### DIFF
--- a/tests/app/api_v0/test_revision.py
+++ b/tests/app/api_v0/test_revision.py
@@ -1,24 +1,15 @@
 # TODO: split E2E test to unit test
+
 import pytest
-from sqlalchemy.orm import Session
 from starlette.testclient import TestClient
 
-from pol.db.tables import ChiiRevHistory
-from tests.conftest import MockUser
+from tests.conftest import MockUserService
 
 person_revisions_api_prefix = "/v0/revisions/persons"
 
 
 @pytest.mark.env("e2e", "database")
-def test_person_revision_basic(
-    client: TestClient,
-    db_session: Session,
-    mock_user: MockUser,
-):
-    for r in db_session.query(ChiiRevHistory.rev_creator).where(
-        ChiiRevHistory.rev_id == 348475
-    ):
-        mock_user(r.rev_creator)
+def test_person_revision_basic(client: TestClient, mock_user_service: MockUserService):
     response = client.get(
         f"{person_revisions_api_prefix}/348475",
     )
@@ -51,14 +42,8 @@ character_revisions_api_prefix = "/v0/revisions/characters"
 
 @pytest.mark.env("e2e", "database")
 def test_character_revision_basic(
-    client: TestClient,
-    db_session: Session,
-    mock_user: MockUser,
+    client: TestClient, mock_user_service: MockUserService
 ):
-    for r in db_session.query(ChiiRevHistory.rev_creator).where(
-        ChiiRevHistory.rev_id == 190704
-    ):
-        mock_user(r.rev_creator)
     response = client.get(
         f"{character_revisions_api_prefix}/190704",
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -95,7 +95,8 @@ class MockUserService:
 def mock_user_service(app: FastAPI):
     service = mock.Mock(wraps=MockUserService())
     app.dependency_overrides[UserService.new] = lambda: service
-    return service
+    yield service
+    app.dependency_overrides.pop(UserService.new, None)
 
 
 class MockAsyncSession(Protocol):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,5 @@
 from abc import abstractmethod
-from typing import Protocol, Generator
+from typing import Iterator, Protocol, Generator
 from datetime import datetime
 from unittest import mock
 from contextlib import asynccontextmanager
@@ -7,6 +7,7 @@ from collections import defaultdict
 
 import redis
 import pytest
+from fastapi import FastAPI
 from _pytest.nodes import Node
 from sqlalchemy.orm import Session, sessionmaker
 from starlette.testclient import TestClient
@@ -15,6 +16,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 import pol.server
 from pol import config
 from pol.db import sa
+from pol.models import Avatar, PublicUser
 from tests.base import async_lambda
 from pol.depends import get_db, get_redis
 from pol.db.const import Gender, BloodType, PersonType, SubjectType, CollectionType
@@ -27,6 +29,7 @@ from pol.db.tables import (
     ChiiSubjectInterest,
     ChiiOauthAccessToken,
 )
+from pol.services.user_service import UserService
 
 
 def pytest_addoption(parser):
@@ -60,6 +63,39 @@ DBSession = sa.sync_session_maker()
 @pytest.fixture()
 def app():
     return pol.server.app
+
+
+class MockUserService:
+    async def get_users_by_id(self, ids: Iterator[int]):
+        id_list = list(ids)
+        for uid in id_list:
+            assert uid > 0
+
+        return {
+            uid: PublicUser(
+                id=uid,
+                username=f"username {uid}",
+                nickname=f"nickname {uid}",
+                avatar=Avatar.from_db_record(""),
+            )
+            for uid in id_list
+        }
+
+    async def get_by_uid(self, uid: int):
+        assert uid > 0
+        return PublicUser(
+            id=uid,
+            username=f"username {uid}",
+            nickname=f"nickname {uid}",
+            avatar=Avatar.from_db_record(""),
+        )
+
+
+@pytest.fixture()
+def mock_user_service(app: FastAPI):
+    service = mock.Mock(wraps=MockUserService())
+    app.dependency_overrides[UserService.new] = lambda: service
+    return service
 
 
 class MockAsyncSession(Protocol):


### PR DESCRIPTION
把`revision`相关用到的`mock_user`方法，换成向`app`注入`Mock`的做法