### PR TITLE
refactor(tests): split fixtures

### DIFF
--- a/tests/app/api_v0/test_auth.py
+++ b/tests/app/api_v0/test_auth.py
@@ -9,8 +9,6 @@ from pol import config
 from pol.models import User, Avatar
 from pol.permission import UserGroup
 
-access_token = "a_development_access_token"
-
 
 @pytest.mark.env("e2e", "database", "redis")
 def test_auth_200(client: TestClient, auth_header):
@@ -20,7 +18,7 @@ def test_auth_200(client: TestClient, auth_header):
 
 
 @pytest.mark.env("e2e", "database", "redis")
-def test_auth_403(client: TestClient):
+def test_auth_403(client: TestClient, access_token: str):
     response = client.get("/v0/me", headers={"Authorization": "Bearer "})
     assert response.status_code == 403, "no token"
 
@@ -55,7 +53,9 @@ def test_auth_cached(client: TestClient, redis_client: Redis):
 
 
 @pytest.mark.env("e2e", "database", "redis")
-def test_auth_cache_ban_cache_fallback(client: TestClient, redis_client: Redis):
+def test_auth_cache_ban_cache_fallback(
+    client: TestClient, redis_client: Redis, access_token: str
+):
     cache_key = config.CACHE_KEY_PREFIX + f"access:{access_token}"
     redis_client.set(
         cache_key,

--- a/tests/app/api_v0/test_collection.py
+++ b/tests/app/api_v0/test_collection.py
@@ -2,7 +2,7 @@ import pytest
 from starlette.testclient import TestClient
 
 from pol.db.const import SubjectType, CollectionType
-from tests.conftest import MockUser
+from tests.fixtures.mock_db_record import MockUser
 
 
 @pytest.mark.env("e2e", "database", "redis")

--- a/tests/app/api_v0/test_revision.py
+++ b/tests/app/api_v0/test_revision.py
@@ -4,7 +4,7 @@ from sqlalchemy.orm import Session
 from starlette.testclient import TestClient
 
 from pol.db.tables import ChiiRevHistory
-from tests.conftest import MockUser
+from tests.fixtures.mock_db_record import MockUser
 
 person_revisions_api_prefix = "/v0/revisions/persons"
 

--- a/tests/app/api_v0/test_revisions.py
+++ b/tests/app/api_v0/test_revisions.py
@@ -11,7 +11,7 @@ person_revisions_api_prefix = "/v0/revisions/persons"
 @pytest.mark.env("e2e", "database")
 def test_person_revisions_basic(
     client: TestClient,
-    mock_user_service,
+    mock_user_service: MockUserService,
 ):
     response = client.get(person_revisions_api_prefix, params={"person_id": 9})
     assert response.status_code == 200
@@ -119,7 +119,9 @@ subject_revisions_api_prefix = "/v0/revisions/subjects"
 
 
 @pytest.mark.env("e2e", "database")
-def test_subject_revisions_basic(client: TestClient, mock_user_service):
+def test_subject_revisions_basic(
+    client: TestClient, mock_user_service: MockUserService
+):
     response = client.get(subject_revisions_api_prefix, params={"subject_id": 26})
     assert response.status_code == 200
     assert response.headers["content-type"] == "application/json"

--- a/tests/app/api_v0/test_revisions.py
+++ b/tests/app/api_v0/test_revisions.py
@@ -4,9 +4,7 @@ import pytest
 from sqlalchemy.orm import Session
 from starlette.testclient import TestClient
 
-import pol.server
 from pol.db.tables import ChiiRevHistory
-from pol.services.user_service import UserService
 from tests.fixtures.mock_db_record import MockUser
 from pol.services.rev_service.person_rev import person_rev_type_filters
 from pol.services.rev_service.character_rev import character_rev_type_filters
@@ -156,7 +154,6 @@ subject_revisions_api_prefix = "/v0/revisions/subjects"
 
 @pytest.mark.env("e2e", "database")
 def test_subject_revisions_basic(client: TestClient, mock_user_service):
-    pol.server.app.dependency_overrides[UserService.new] = mock_user_service
     response = client.get(subject_revisions_api_prefix, params={"subject_id": 26})
     assert response.status_code == 200
     assert response.headers["content-type"] == "application/json"

--- a/tests/app/api_v0/test_revisions.py
+++ b/tests/app/api_v0/test_revisions.py
@@ -8,8 +8,8 @@ from starlette.testclient import TestClient
 import pol.server
 from pol.models import Avatar, PublicUser
 from pol.db.tables import ChiiRevHistory
-from tests.conftest import MockUser
 from pol.services.user_service import UserService
+from tests.fixtures.mock_db_record import MockUser
 from pol.services.rev_service.person_rev import person_rev_type_filters
 from pol.services.rev_service.character_rev import character_rev_type_filters
 

--- a/tests/app/api_v0/test_subject.py
+++ b/tests/app/api_v0/test_subject.py
@@ -14,9 +14,9 @@ from pol.db import sa
 from pol.models import Subject
 from tests.base import async_lambda
 from pol.db.tables import ChiiSubjectField
-from tests.conftest import MockRedis
 from pol.api.v0.depends import optional_user
 from pol.api.v0.depends.auth import Guest
+from tests.fixtures.mock_redis import MockRedis
 from pol.services.subject_service import SubjectService
 
 fixtures_path = Path(__file__).parent.joinpath("fixtures")

--- a/tests/app/test_user_service.py
+++ b/tests/app/test_user_service.py
@@ -6,8 +6,8 @@ from sqlalchemy.orm import Session
 from pol.db import sa
 from tests.base import async_test
 from pol.db.tables import ChiiMember
-from tests.conftest import MockUser
 from pol.services.user_service import UserService
+from tests.fixtures.mock_db_record import MockUser
 
 
 @pytest.mark.env("database")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,32 +1,16 @@
-from abc import abstractmethod
-from typing import Protocol, Generator
-from datetime import datetime
-from unittest import mock
-from contextlib import asynccontextmanager
-from collections import defaultdict
-
-import redis
 import pytest
+from fastapi import FastAPI
 from _pytest.nodes import Node
-from sqlalchemy.orm import Session, sessionmaker
 from starlette.testclient import TestClient
-from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 
 import pol.server
-from pol import config
-from pol.db import sa
-from tests.base import async_lambda
-from pol.depends import get_db, get_redis
-from pol.db.const import Gender, BloodType, PersonType, SubjectType, CollectionType
-from pol.db.tables import (
-    ChiiMember,
-    ChiiPerson,
-    ChiiSubject,
-    ChiiPersonField,
-    ChiiSubjectField,
-    ChiiSubjectInterest,
-    ChiiOauthAccessToken,
-)
+
+pytest_plugins = [
+    "tests.fixtures.mock_redis",
+    "tests.fixtures.mock_db",
+    "tests.fixtures.mock_db_record",
+    "tests.fixtures.mock_service",
+]
 
 
 def pytest_addoption(parser):
@@ -38,7 +22,7 @@ def pytest_addoption(parser):
 
 
 def pytest_configure(config):
-    # register an additional marker
+    # register an additional `pytest.mark.env` marker
     config.addinivalue_line(
         "markers",
         "env(name1, ...name2): mark test to run only on named environment",
@@ -46,6 +30,7 @@ def pytest_configure(config):
 
 
 def pytest_runtest_setup(item: Node):
+    """skip by `@pytest.mark.env` and flag defined in `pytest_addoption`"""
     mark = item.get_closest_marker(name="env")
     if not mark:
         return
@@ -54,102 +39,10 @@ def pytest_runtest_setup(item: Node):
             pytest.skip(f"test skipped without flag --{name}")
 
 
-DBSession = sa.sync_session_maker()
-
-
 @pytest.fixture()
-def app():
+def app() -> FastAPI:
+    """app instance"""
     return pol.server.app
-
-
-class MockAsyncSession(Protocol):
-    get: mock.AsyncMock
-    scalar: mock.AsyncMock
-    scalars: mock.AsyncMock
-
-
-@pytest.fixture()
-def mock_db(app) -> MockAsyncSession:
-    """mock mock AsyncSession, also override dependency `get_db` for all router"""
-    db = mock.Mock()
-    db.get = mock.AsyncMock(return_value=None)
-    db.scalar = mock.AsyncMock(return_value=None)
-    db.scalars = mock.AsyncMock(return_value=None)
-    app.dependency_overrides[get_db] = async_lambda(db)
-    yield db
-    app.dependency_overrides.pop(get_db, None)
-
-
-class MockRedis(Protocol):
-    get: mock.AsyncMock
-    set_json: mock.AsyncMock
-    get_with_model: mock.AsyncMock
-
-
-@pytest.fixture()
-def mock_redis(app) -> MockRedis:
-    """mock redis client, also override dependency `get_redis` for all router"""
-    r = mock.Mock()
-    r.set_json = mock.AsyncMock()
-    r.get = mock.AsyncMock(return_value=None)
-    r.get_with_model = mock.AsyncMock(return_value=None)
-    app.dependency_overrides[get_redis] = async_lambda(r)
-    yield r
-    app.dependency_overrides.pop(get_redis, None)
-
-
-@pytest.fixture()
-def db_session():
-    db_session = DBSession()
-    try:
-        yield db_session
-    except Exception:  # pragma: no cover
-        db_session.rollback()
-        raise
-    finally:
-        db_session.close()
-
-
-@pytest.fixture()
-def AsyncSessionMaker():
-    @asynccontextmanager
-    async def get():
-        engine = create_async_engine(
-            "mysql+aiomysql://{}:{}@{}:{}/{}".format(
-                config.MYSQL_USER,
-                config.MYSQL_PASS,
-                config.MYSQL_HOST,
-                config.MYSQL_PORT,
-                config.MYSQL_DB,
-            ),
-            pool_recycle=14400,
-            pool_size=10,
-            max_overflow=20,
-        )
-
-        SS = sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
-
-        async with SS() as s:
-            yield s
-
-        # ensure to dispose the engine after usage.
-        # otherwise asyncio will raise a RuntimeError
-        await engine.dispose()
-
-    return get
-
-
-@pytest.fixture()
-def redis_client():
-    with redis.Redis.from_url(config.REDIS_URI) as redis_client:
-        redis_client.flushdb()
-        try:
-            yield redis_client
-        finally:
-            redis_client.flushdb()
-
-
-access_token = "a_development_access_token"
 
 
 @pytest.fixture()
@@ -160,289 +53,10 @@ def client(app):
 
 
 @pytest.fixture()
-def auth_header():
+def access_token():
+    return "a_development_access_token"
+
+
+@pytest.fixture()
+def auth_header(access_token: str):
     return {"Authorization": f"Bearer {access_token}"}
-
-
-@pytest.fixture()
-def mock_subject(db_session: Session):
-    mock_subject_id = set()
-    delete_query = defaultdict(list)
-
-    def mock_id(
-        subject_id: int,
-        subject_name="",
-        subject_type=SubjectType.anime,
-        subject_name_cn="",
-        subject_uid=1,
-        subject_creator=1,
-        subject_image="",
-        field_infobox="",
-        field_summary="",
-        field_5="",
-        subject_idx_cn="",
-        subject_airtime=1,
-        subject_nsfw=0,
-        subject_ban=0,
-        field_tags="",
-        field_airtime=1,
-        field_year=2007,
-        field_mon=1,
-        field_week_day=3,
-        field_date=datetime.now().astimezone().date(),
-    ):
-        delete_query[ChiiSubject].append(ChiiSubject.subject_id == subject_id)
-        delete_query[ChiiSubjectField].append(ChiiSubjectField.field_sid == subject_id)
-
-        check_exist(db_session, delete_query)
-        mock_subject_id.add(subject_id)
-
-        db_session.add(
-            ChiiSubject(
-                subject_id=subject_id,
-                subject_name=subject_name,
-                subject_name_cn=subject_name_cn,
-                subject_uid=subject_uid,
-                subject_type_id=subject_type,
-                subject_creator=subject_creator,
-                subject_image=subject_image,
-                field_infobox=field_infobox,
-                field_summary=field_summary,
-                field_5=field_5,
-                subject_idx_cn=subject_idx_cn,
-                subject_airtime=subject_airtime,
-                subject_nsfw=subject_nsfw,
-                subject_ban=subject_ban,
-            )
-        )
-        db_session.add(
-            ChiiSubjectField(
-                field_sid=subject_id,
-                field_tags=field_tags,
-                field_airtime=field_airtime,
-                field_year=field_year,
-                field_mon=field_mon,
-                field_week_day=field_week_day,
-                field_date=field_date,
-            )
-        )
-        db_session.commit()
-
-    try:
-        yield mock_id
-    finally:
-        for table, where in delete_query.items():
-            db_session.execute(sa.delete(table).where(sa.or_(*where)))
-        db_session.commit()
-
-
-class MockUser(Protocol):
-    @abstractmethod
-    def __call__(
-        self,
-        user_id: int,
-        access_token: str = "",
-        username: str = "",
-        expires: datetime = datetime.now(),
-    ) -> None:
-        pass
-
-
-@pytest.fixture()
-def mock_person(db_session: Session):
-    mock_person_id = set()
-    delete_query = defaultdict(list)
-
-    def mock_id(
-        prsn_id: int,
-        prsn_name="",
-        prsn_type=PersonType.person,
-        prsn_infobox="",
-        prsn_producer=0,
-        prsn_mangaka=0,
-        prsn_artist=1,
-        prsn_seiyu=0,
-        prsn_writer=0,
-        prsn_illustrator=0,
-        prsn_actor=0,
-        prsn_summary="",
-        prsn_img="",
-        prsn_img_anidb="",
-        prsn_comment=0,
-        prsn_collects=0,
-        prsn_dateline=0,
-        prsn_lastpost=0,
-        prsn_lock=0,
-        prsn_anidb_id=0,
-        prsn_ban=0,
-        prsn_redirect=0,
-        prsn_nsfw=0,
-        gender=Gender.male,
-        bloodtype=BloodType.o,
-        birth_year=2000,
-        birth_mon=1,
-        birth_day=1,
-    ):
-        delete_query[ChiiPerson].append(ChiiPerson.prsn_id == prsn_id)
-        delete_query[ChiiPersonField].append(ChiiPersonField.prsn_id == prsn_id)
-
-        check_exist(db_session, delete_query)
-        mock_person_id.add(prsn_id)
-
-        db_session.add(
-            ChiiPerson(
-                prsn_id=prsn_id,
-                prsn_name=prsn_name,
-                prsn_type=prsn_type,
-                prsn_infobox=prsn_infobox,
-                prsn_producer=prsn_producer,
-                prsn_mangaka=prsn_mangaka,
-                prsn_artist=prsn_artist,
-                prsn_seiyu=prsn_seiyu,
-                prsn_writer=prsn_writer,
-                prsn_illustrator=prsn_illustrator,
-                prsn_actor=prsn_actor,
-                prsn_summary=prsn_summary,
-                prsn_img=prsn_img,
-                prsn_img_anidb=prsn_img_anidb,
-                prsn_comment=prsn_comment,
-                prsn_collects=prsn_collects,
-                prsn_dateline=prsn_dateline,
-                prsn_lastpost=prsn_lastpost,
-                prsn_lock=prsn_lock,
-                prsn_anidb_id=prsn_anidb_id,
-                prsn_ban=prsn_ban,
-                prsn_redirect=prsn_redirect,
-                prsn_nsfw=prsn_nsfw,
-            )
-        )
-        db_session.add(
-            ChiiPersonField(
-                prsn_cat="prsn",
-                prsn_id=prsn_id,
-                gender=gender,
-                bloodtype=bloodtype,
-                birth_year=birth_year,
-                birth_mon=birth_mon,
-                birth_day=birth_day,
-            )
-        )
-        db_session.commit()
-
-    try:
-        yield mock_id
-    finally:
-        for table, where in delete_query.items():
-            db_session.execute(sa.delete(table).where(sa.or_(*where)))
-        db_session.commit()
-
-
-@pytest.fixture()
-def mock_user(db_session: Session) -> Generator[MockUser, None, None]:
-    mock_user_id = set()
-    mock_token = set()
-    delete_query = defaultdict(list)
-
-    def mock_id(
-        user_id: int,
-        access_token: str = "",
-        username: str = "",
-        expires=datetime.now(),
-    ):
-        if user_id in mock_user_id and (not access_token or access_token in mock_token):
-            return
-        mock_user_id.add(user_id)
-        mock_token.add(access_token)
-        if access_token:
-            delete_query[ChiiOauthAccessToken].append(
-                ChiiOauthAccessToken.access_token == access_token
-            )
-        delete_query[ChiiMember].append(ChiiMember.uid == user_id)
-        try:
-            check_exist(db_session, delete_query)
-        except ValueError as e:
-            print(e)
-            return
-
-        if access_token:
-            db_session.add(
-                ChiiOauthAccessToken(
-                    access_token=access_token,
-                    client_id="",
-                    user_id=user_id,
-                    expires=expires,
-                    scope=None,
-                )
-            )
-
-        db_session.add(
-            ChiiMember(
-                uid=user_id,
-                username=username or f"mock_{user_id}",
-                nickname="",
-                avatar="",
-                groupid=10,
-                sign="",
-            )
-        )
-        db_session.commit()
-
-    try:
-        yield mock_id
-    finally:
-        for table, where in delete_query.items():
-            db_session.execute(sa.delete(table).where(sa.or_(*where)))
-        db_session.commit()
-
-
-@pytest.fixture()
-def mock_user_collection(db_session: Session):
-    mock_ids = set()
-    delete_query = defaultdict(list)
-
-    def mock_collection(
-        id: int,
-        user_id: int,
-        subject_id: int,
-        subject_type=SubjectType.anime,
-        type=CollectionType.doing,
-        private=False,
-    ):
-        delete_query[ChiiSubjectInterest].append(ChiiSubjectInterest.id == id)
-        check_exist(db_session, delete_query)
-
-        mock_ids.add(id)
-
-        db_session.add(
-            ChiiSubjectInterest(
-                id=id,
-                user_id=user_id,
-                subject_id=subject_id,
-                subject_type=subject_type,
-                type=type,
-                private=private,
-            )
-        )
-
-        db_session.commit()
-
-    try:
-        yield mock_collection
-    finally:
-        for table, where in delete_query.items():
-            db_session.execute(sa.delete(table).where(sa.or_(*where)))
-        db_session.commit()
-
-
-def check_exist(db_session: Session, quries):
-    for Table, q in quries.items():
-        query = q[-1]
-        r = db_session.execute(sa.select(Table).where(query)).all()
-        if r:  # pragma: no cover
-            raise ValueError(
-                f"record {query.left.name} == {repr(query.right.value)}"
-                f" exists in table {Table}, can't mock it"
-            )
-
-    for Table, q in quries.items():
-        db_session.execute(sa.delete(Table).where(q[-1]))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -76,7 +76,8 @@ def mock_db(app) -> MockAsyncSession:
     db.scalar = mock.AsyncMock(return_value=None)
     db.scalars = mock.AsyncMock(return_value=None)
     app.dependency_overrides[get_db] = async_lambda(db)
-    return db
+    yield db
+    app.dependency_overrides.pop(get_db, None)
 
 
 class MockRedis(Protocol):
@@ -93,7 +94,8 @@ def mock_redis(app) -> MockRedis:
     r.get = mock.AsyncMock(return_value=None)
     r.get_with_model = mock.AsyncMock(return_value=None)
     app.dependency_overrides[get_redis] = async_lambda(r)
-    return r
+    yield r
+    app.dependency_overrides.pop(get_redis, None)
 
 
 @pytest.fixture()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ from starlette.testclient import TestClient
 
 import pol.server
 
+# mockers
 pytest_plugins = [
     "tests.fixtures.mock_redis",
     "tests.fixtures.mock_db",

--- a/tests/fixtures/mock_db.py
+++ b/tests/fixtures/mock_db.py
@@ -1,0 +1,58 @@
+"""
+mock `sqlalchemy.ext.asyncio.AsyncSession` returned by `pol.depends.get_db`
+"""
+from typing import Protocol
+from unittest import mock
+from contextlib import asynccontextmanager
+
+import pytest
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+
+from pol import config
+from tests.base import async_lambda
+from pol.depends import get_db
+
+
+class MockAsyncSession(Protocol):
+    get: mock.AsyncMock
+    scalar: mock.AsyncMock
+    scalars: mock.AsyncMock
+
+
+@pytest.fixture()
+def mock_db(app) -> MockAsyncSession:
+    """mock mock AsyncSession, also override dependency `get_db` for all router"""
+    db = mock.Mock()
+    db.get = mock.AsyncMock(return_value=None)
+    db.scalar = mock.AsyncMock(return_value=None)
+    db.scalars = mock.AsyncMock(return_value=None)
+    app.dependency_overrides[get_db] = async_lambda(db)
+    yield db
+    app.dependency_overrides.pop(get_db, None)
+
+
+@pytest.fixture()
+def AsyncSessionMaker():
+    @asynccontextmanager
+    async def get():
+        engine = create_async_engine(
+            "mysql+aiomysql://{}:{}@{}:{}/{}".format(
+                config.MYSQL_USER,
+                config.MYSQL_PASS,
+                config.MYSQL_HOST,
+                config.MYSQL_PORT,
+                config.MYSQL_DB,
+            )
+        )
+
+        SS = sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+
+        async with SS() as s:
+            yield s
+
+        # ensure to dispose the engine after usage.
+        # otherwise, asyncio will raise a RuntimeError
+        await engine.dispose()
+
+    return get

--- a/tests/fixtures/mock_db.py
+++ b/tests/fixtures/mock_db.py
@@ -10,7 +10,6 @@ from sqlalchemy.orm import sessionmaker
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 
 from pol import config
-from tests.base import async_lambda
 from pol.depends import get_db
 
 
@@ -27,7 +26,11 @@ def mock_db(app) -> MockAsyncSession:
     db.get = mock.AsyncMock(return_value=None)
     db.scalar = mock.AsyncMock(return_value=None)
     db.scalars = mock.AsyncMock(return_value=None)
-    app.dependency_overrides[get_db] = async_lambda(db)
+
+    async def mocker():
+        return db
+
+    app.dependency_overrides[get_db] = mocker
     yield db
     app.dependency_overrides.pop(get_db, None)
 

--- a/tests/fixtures/mock_db_record.py
+++ b/tests/fixtures/mock_db_record.py
@@ -1,0 +1,322 @@
+"""
+Utilities to mock MySQL record
+
+Database records added by fixtures should be removed after tests.
+"""
+from abc import abstractmethod
+from typing import Protocol, Generator
+from datetime import datetime
+from collections import defaultdict
+
+import pytest
+from sqlalchemy.orm import Session
+
+from pol.db import sa
+from pol.db.const import Gender, BloodType, PersonType, SubjectType, CollectionType
+from pol.db.tables import (
+    ChiiMember,
+    ChiiPerson,
+    ChiiSubject,
+    ChiiPersonField,
+    ChiiSubjectField,
+    ChiiSubjectInterest,
+    ChiiOauthAccessToken,
+)
+
+DBSession = sa.sync_session_maker()
+
+
+@pytest.fixture()
+def db_session():
+    db_session = DBSession()
+    try:
+        yield db_session
+    except Exception:  # pragma: no cover
+        db_session.rollback()
+        raise
+    finally:
+        db_session.close()
+
+
+@pytest.fixture()
+def mock_subject(db_session: Session):
+    mock_subject_id = set()
+    delete_query = defaultdict(list)
+
+    def mock_id(
+        subject_id: int,
+        subject_name="",
+        subject_type=SubjectType.anime,
+        subject_name_cn="",
+        subject_uid=1,
+        subject_creator=1,
+        subject_image="",
+        field_infobox="",
+        field_summary="",
+        field_5="",
+        subject_idx_cn="",
+        subject_airtime=1,
+        subject_nsfw=0,
+        subject_ban=0,
+        field_tags="",
+        field_airtime=1,
+        field_year=2007,
+        field_mon=1,
+        field_week_day=3,
+        field_date=datetime.now().astimezone().date(),
+    ):
+        delete_query[ChiiSubject].append(ChiiSubject.subject_id == subject_id)
+        delete_query[ChiiSubjectField].append(ChiiSubjectField.field_sid == subject_id)
+
+        check_exist(db_session, delete_query)
+        mock_subject_id.add(subject_id)
+
+        db_session.add(
+            ChiiSubject(
+                subject_id=subject_id,
+                subject_name=subject_name,
+                subject_name_cn=subject_name_cn,
+                subject_uid=subject_uid,
+                subject_type_id=subject_type,
+                subject_creator=subject_creator,
+                subject_image=subject_image,
+                field_infobox=field_infobox,
+                field_summary=field_summary,
+                field_5=field_5,
+                subject_idx_cn=subject_idx_cn,
+                subject_airtime=subject_airtime,
+                subject_nsfw=subject_nsfw,
+                subject_ban=subject_ban,
+            )
+        )
+        db_session.add(
+            ChiiSubjectField(
+                field_sid=subject_id,
+                field_tags=field_tags,
+                field_airtime=field_airtime,
+                field_year=field_year,
+                field_mon=field_mon,
+                field_week_day=field_week_day,
+                field_date=field_date,
+            )
+        )
+        db_session.commit()
+
+    try:
+        yield mock_id
+    finally:
+        for table, where in delete_query.items():
+            db_session.execute(sa.delete(table).where(sa.or_(*where)))
+        db_session.commit()
+
+
+@pytest.fixture()
+def mock_person(db_session: Session):
+    mock_person_id = set()
+    delete_query = defaultdict(list)
+
+    def mock_id(
+        prsn_id: int,
+        prsn_name="",
+        prsn_type=PersonType.person,
+        prsn_infobox="",
+        prsn_producer=0,
+        prsn_mangaka=0,
+        prsn_artist=1,
+        prsn_seiyu=0,
+        prsn_writer=0,
+        prsn_illustrator=0,
+        prsn_actor=0,
+        prsn_summary="",
+        prsn_img="",
+        prsn_img_anidb="",
+        prsn_comment=0,
+        prsn_collects=0,
+        prsn_dateline=0,
+        prsn_lastpost=0,
+        prsn_lock=0,
+        prsn_anidb_id=0,
+        prsn_ban=0,
+        prsn_redirect=0,
+        prsn_nsfw=0,
+        gender=Gender.male,
+        bloodtype=BloodType.o,
+        birth_year=2000,
+        birth_mon=1,
+        birth_day=1,
+    ):
+        delete_query[ChiiPerson].append(ChiiPerson.prsn_id == prsn_id)
+        delete_query[ChiiPersonField].append(ChiiPersonField.prsn_id == prsn_id)
+
+        check_exist(db_session, delete_query)
+        mock_person_id.add(prsn_id)
+
+        db_session.add(
+            ChiiPerson(
+                prsn_id=prsn_id,
+                prsn_name=prsn_name,
+                prsn_type=prsn_type,
+                prsn_infobox=prsn_infobox,
+                prsn_producer=prsn_producer,
+                prsn_mangaka=prsn_mangaka,
+                prsn_artist=prsn_artist,
+                prsn_seiyu=prsn_seiyu,
+                prsn_writer=prsn_writer,
+                prsn_illustrator=prsn_illustrator,
+                prsn_actor=prsn_actor,
+                prsn_summary=prsn_summary,
+                prsn_img=prsn_img,
+                prsn_img_anidb=prsn_img_anidb,
+                prsn_comment=prsn_comment,
+                prsn_collects=prsn_collects,
+                prsn_dateline=prsn_dateline,
+                prsn_lastpost=prsn_lastpost,
+                prsn_lock=prsn_lock,
+                prsn_anidb_id=prsn_anidb_id,
+                prsn_ban=prsn_ban,
+                prsn_redirect=prsn_redirect,
+                prsn_nsfw=prsn_nsfw,
+            )
+        )
+        db_session.add(
+            ChiiPersonField(
+                prsn_cat="prsn",
+                prsn_id=prsn_id,
+                gender=gender,
+                bloodtype=bloodtype,
+                birth_year=birth_year,
+                birth_mon=birth_mon,
+                birth_day=birth_day,
+            )
+        )
+        db_session.commit()
+
+    try:
+        yield mock_id
+    finally:
+        for table, where in delete_query.items():
+            db_session.execute(sa.delete(table).where(sa.or_(*where)))
+        db_session.commit()
+
+
+class MockUser(Protocol):
+    @abstractmethod
+    def __call__(
+        self,
+        user_id: int,
+        access_token: str = "",
+        username: str = "",
+        expires: datetime = datetime.now(),
+    ) -> None:
+        pass
+
+
+@pytest.fixture()
+def mock_user(db_session: Session) -> Generator[MockUser, None, None]:
+    mock_user_id = set()
+    mock_token = set()
+    delete_query = defaultdict(list)
+
+    def mock_id(
+        user_id: int,
+        access_token: str = "",
+        username: str = "",
+        expires=datetime.now(),
+    ):
+        if user_id in mock_user_id and (not access_token or access_token in mock_token):
+            return
+        mock_user_id.add(user_id)
+        mock_token.add(access_token)
+        if access_token:
+            delete_query[ChiiOauthAccessToken].append(
+                ChiiOauthAccessToken.access_token == access_token
+            )
+        delete_query[ChiiMember].append(ChiiMember.uid == user_id)
+        try:
+            check_exist(db_session, delete_query)
+        except ValueError as e:
+            print(e)
+            return
+
+        if access_token:
+            db_session.add(
+                ChiiOauthAccessToken(
+                    access_token=access_token,
+                    client_id="",
+                    user_id=user_id,
+                    expires=expires,
+                    scope=None,
+                )
+            )
+
+        db_session.add(
+            ChiiMember(
+                uid=user_id,
+                username=username or f"mock_{user_id}",
+                nickname="",
+                avatar="",
+                groupid=10,
+                sign="",
+            )
+        )
+        db_session.commit()
+
+    try:
+        yield mock_id
+    finally:
+        for table, where in delete_query.items():
+            db_session.execute(sa.delete(table).where(sa.or_(*where)))
+        db_session.commit()
+
+
+@pytest.fixture()
+def mock_user_collection(db_session: Session):
+    mock_ids = set()
+    delete_query = defaultdict(list)
+
+    def mock_collection(
+        id: int,
+        user_id: int,
+        subject_id: int,
+        subject_type=SubjectType.anime,
+        type=CollectionType.doing,
+        private=False,
+    ):
+        delete_query[ChiiSubjectInterest].append(ChiiSubjectInterest.id == id)
+        check_exist(db_session, delete_query)
+
+        mock_ids.add(id)
+
+        db_session.add(
+            ChiiSubjectInterest(
+                id=id,
+                user_id=user_id,
+                subject_id=subject_id,
+                subject_type=subject_type,
+                type=type,
+                private=private,
+            )
+        )
+
+        db_session.commit()
+
+    try:
+        yield mock_collection
+    finally:
+        for table, where in delete_query.items():
+            db_session.execute(sa.delete(table).where(sa.or_(*where)))
+        db_session.commit()
+
+
+def check_exist(db_session: Session, quries):
+    for Table, q in quries.items():
+        query = q[-1]
+        r = db_session.execute(sa.select(Table).where(query)).all()
+        if r:  # pragma: no cover
+            raise ValueError(
+                f"record {query.left.name} == {repr(query.right.value)}"
+                f" exists in table {Table}, can't mock it"
+            )
+
+    for Table, q in quries.items():
+        db_session.execute(sa.delete(Table).where(q[-1]))

--- a/tests/fixtures/mock_db_record.py
+++ b/tests/fixtures/mock_db_record.py
@@ -232,11 +232,7 @@ def mock_user(db_session: Session) -> Generator[MockUser, None, None]:
                 ChiiOauthAccessToken.access_token == access_token
             )
         delete_query[ChiiMember].append(ChiiMember.uid == user_id)
-        try:
-            check_exist(db_session, delete_query)
-        except ValueError as e:
-            print(e)
-            return
+        check_exist(db_session, delete_query)
 
         if access_token:
             db_session.add(

--- a/tests/fixtures/mock_redis.py
+++ b/tests/fixtures/mock_redis.py
@@ -1,0 +1,39 @@
+"""mock redis"""
+from typing import Protocol
+from unittest import mock
+
+import redis
+import pytest
+
+from pol import config
+from tests.base import async_lambda
+from pol.depends import get_redis
+
+
+class MockRedis(Protocol):
+    get: mock.AsyncMock
+    set_json: mock.AsyncMock
+    get_with_model: mock.AsyncMock
+
+
+@pytest.fixture()
+def mock_redis(app) -> MockRedis:
+    """mock redis client, also override dependency `get_redis` for all router"""
+    r = mock.Mock()
+    r.set_json = mock.AsyncMock()
+    r.get = mock.AsyncMock(return_value=None)
+    r.get_with_model = mock.AsyncMock(return_value=None)
+    app.dependency_overrides[get_redis] = async_lambda(r)
+    yield r
+    app.dependency_overrides.pop(get_redis, None)
+
+
+@pytest.fixture()
+def redis_client():
+    """fixture to access redis server"""
+    with redis.Redis.from_url(config.REDIS_URI) as redis_client:
+        redis_client.flushdb()
+        try:
+            yield redis_client
+        finally:
+            redis_client.flushdb()

--- a/tests/fixtures/mock_redis.py
+++ b/tests/fixtures/mock_redis.py
@@ -6,7 +6,6 @@ import redis
 import pytest
 
 from pol import config
-from tests.base import async_lambda
 from pol.depends import get_redis
 
 
@@ -23,7 +22,11 @@ def mock_redis(app) -> MockRedis:
     r.set_json = mock.AsyncMock()
     r.get = mock.AsyncMock(return_value=None)
     r.get_with_model = mock.AsyncMock(return_value=None)
-    app.dependency_overrides[get_redis] = async_lambda(r)
+
+    async def mocker():
+        return r
+
+    app.dependency_overrides[get_redis] = mocker
     yield r
     app.dependency_overrides.pop(get_redis, None)
 

--- a/tests/fixtures/mock_service.py
+++ b/tests/fixtures/mock_service.py
@@ -1,0 +1,46 @@
+from typing import Dict, Iterator
+from unittest import mock
+
+import pytest
+from fastapi import FastAPI
+
+from pol.models import Avatar, PublicUser
+from pol.services.user_service import UserService
+
+
+class MockUserService:
+    async def get_users_by_id(self, ids: Iterator[int]) -> Dict[int, PublicUser]:
+        ids = list(ids)
+        for uid in ids:
+            assert uid > 0
+
+        return {
+            uid: PublicUser(
+                id=uid,
+                username=f"username {uid}",
+                nickname=f"nickname {uid}",
+                avatar=Avatar.from_db_record(""),
+            )
+            for uid in ids
+        }
+
+    async def get_by_uid(self, uid: int) -> PublicUser:
+        assert uid > 0
+        return PublicUser(
+            id=uid,
+            username=f"username {uid}",
+            nickname=f"nickname {uid}",
+            avatar=Avatar.from_db_record(""),
+        )
+
+
+@pytest.fixture()
+def mock_user_service(app: FastAPI):
+    service = mock.Mock(wraps=MockUserService())
+
+    async def mocker():
+        return service
+
+    app.dependency_overrides[UserService.new] = mocker
+    yield service
+    app.dependency_overrides.pop(UserService.new, None)


### PR DESCRIPTION
`mock_db` 和 `mock_redis` 在某些情况下可能不会正常被重置