### PR TITLE
add __all__ to python files that misses it

### DIFF
--- a/pol/api/v0/character.py
+++ b/pol/api/v0/character.py
@@ -23,6 +23,8 @@ from pol.api.v0.utils import person_images, subject_images
 from pol.api.v0.models import RelatedSubject, CharacterDetail, CharacterPerson
 from pol.redis.json_cache import JSONRedis
 
+__all__ = ["get_character_detail", "get_person_subjects", "get_character_persons"]
+
 router = APIRouter(tags=["角色"], route_class=ErrorCatchRoute)
 
 api_base = "/v0/characters"

--- a/pol/api/v0/depends/auth/schema.py
+++ b/pol/api/v0/depends/auth/schema.py
@@ -8,6 +8,8 @@ from fastapi.security.utils import get_authorization_scheme_param
 
 from pol import res
 
+__all__ = ["OptionalHTTPBearer", "HTTPBearer"]
+
 
 class OptionalHTTPBearer(SecurityBase):
     def __init__(

--- a/pol/api/v0/episode.py
+++ b/pol/api/v0/episode.py
@@ -20,6 +20,8 @@ from pol.http_cache.depends import CacheControl
 from pol.api.v0.depends.auth import optional_user
 from pol.api.v0.models.subject import Episode, EpisodeDetail
 
+__all__ = ["Pager", "get_episodes", "add_episode", "get_episode"]
+
 router = APIRouter(tags=["章节"], route_class=ErrorCatchRoute)
 
 

--- a/pol/api/v0/me.py
+++ b/pol/api/v0/me.py
@@ -8,6 +8,8 @@ from pol.router import ErrorCatchRoute
 from pol.permission import UserGroup
 from pol.api.v0.depends.auth import User, get_current_user
 
+__all__ = ["Me", "get_user"]
+
 router = APIRouter(tags=["用户"], route_class=ErrorCatchRoute)
 
 

--- a/pol/api/v0/models/base.py
+++ b/pol/api/v0/models/base.py
@@ -2,6 +2,8 @@ from typing import List, Generic, TypeVar
 
 from pydantic.generics import GenericModel
 
+__all__ = ["Paged"]
+
 T = TypeVar("T")
 
 

--- a/pol/api/v0/models/creator.py
+++ b/pol/api/v0/models/creator.py
@@ -1,5 +1,7 @@
 from pydantic import BaseModel
 
+__all__ = ["Creator"]
+
 
 class Creator(BaseModel):
     __doc__ = '意义同<a href="#model-Me">Me</a>'

--- a/pol/api/v0/models/revision.py
+++ b/pol/api/v0/models/revision.py
@@ -5,6 +5,8 @@ from pydantic import Field, BaseModel
 
 from .creator import Creator
 
+__all__ = ["Revision", "DetailedRevision"]
+
 
 class Revision(BaseModel):
     id: int

--- a/pol/api/v0/models/subject.py
+++ b/pol/api/v0/models/subject.py
@@ -4,6 +4,15 @@ from pydantic import Field, BaseModel
 
 from pol.api.v0.models.wiki import Wiki
 
+__all__ = ["Rating",
+           "Images",
+           "Collection",
+           "Tag",
+           "Subject",
+           "RelatedSubject",
+           "Episode",
+           "EpisodeDetail"]
+
 
 class Rating(BaseModel):
     rank: int

--- a/pol/api/v0/models/wiki.py
+++ b/pol/api/v0/models/wiki.py
@@ -2,6 +2,8 @@ from typing import List, Union
 
 from pydantic import BaseModel
 
+__all__ = ["V", "KV", "Item"]
+
 
 class V(BaseModel):
     v: str

--- a/pol/api/v0/person.py
+++ b/pol/api/v0/person.py
@@ -23,6 +23,11 @@ from pol.api.v0.utils import get_career, person_images, subject_images
 from pol.api.v0.models import PersonDetail, RelatedSubject, PersonCharacter
 from pol.redis.json_cache import JSONRedis
 
+__all__ = ["get_person",
+           "get_person_subjects",
+           "get_person_characters",
+           "person_img_url"]
+
 router = APIRouter(tags=["人物"], route_class=ErrorCatchRoute)
 
 api_base = "/v0/persons"

--- a/pol/api/v0/revision.py
+++ b/pol/api/v0/revision.py
@@ -12,6 +12,15 @@ from pol.services.rev_service import RevisionService
 from pol.services.user_service import UserService
 from pol.api.v0.models.revision import Revision, DetailedRevision
 
+__all__ = ["get_person_revisions",
+           "get_person_revision",
+           "get_character_revisions",
+           "get_character_revision",
+           "get_subject_revisions",
+           "get_subject_revision",
+           "get_episode_revisions",
+           "get_episode_revision"]
+
 router = APIRouter(prefix="/revisions", tags=["编辑历史"], route_class=ErrorCatchRoute)
 
 

--- a/pol/api/v0/subject.py
+++ b/pol/api/v0/subject.py
@@ -39,6 +39,11 @@ from pol.api.v0.depends.auth import optional_user
 from pol.api.v0.models.subject import Subject, RelatedSubject
 from pol.services.subject_service import SubjectService
 
+__all__ = ["get_subject_by_id",
+           "get_subject_persons",
+           "get_subject_characters",
+           "get_subject_relations"]
+
 router = APIRouter(tags=["条目"], route_class=ErrorCatchRoute)
 
 api_base = "/v0/subjects"

--- a/pol/api/v0/user/collection.py
+++ b/pol/api/v0/user/collection.py
@@ -18,6 +18,8 @@ from pol.api.v0.models import Paged, Pager
 from pol.api.v0.depends import get_public_user
 from pol.api.v0.depends.auth import optional_user
 
+__all__ = ["UserCollection", "get_user_collection", "tags"]
+
 router = APIRouter(
     tags=["用户"],
     route_class=ErrorCatchRoute,

--- a/pol/api/v0/utils.py
+++ b/pol/api/v0/utils.py
@@ -2,6 +2,8 @@ from typing import Dict, List, Optional
 
 from pol.db.tables import ChiiPerson
 
+__all__ = ["person_images", "subject_images", "get_career", "short_description"]
+
 
 def person_images(s: Optional[str]) -> Optional[Dict[str, str]]:
     if not s:

--- a/pol/curd/base.py
+++ b/pol/curd/base.py
@@ -5,6 +5,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from pol.db import sa
 from pol.db.tables import Base
 
+__all__ = ["count"]
+
 T = TypeVar("T", bound=Base)
 
 

--- a/pol/curd/exceptions.py
+++ b/pol/curd/exceptions.py
@@ -1,5 +1,7 @@
 from typing import Any
 
+__all__ = ["NotFoundError"]
+
 
 class NotFoundError(Exception):
     def __init__(self, details: Any = None):

--- a/pol/db/const.py
+++ b/pol/db/const.py
@@ -10,6 +10,19 @@ from pol.db._const import (
     staff_job_music,
 )
 
+__all__ = ["IntEnum",
+           "BloodType",
+           "CollectionType",
+           "CharacterType",
+           "PersonType",
+           "Gender",
+           "EpType",
+           "SubjectType",
+           "get_character_rel",
+           "Relation",
+           "Platform",
+           "RevisionType"]
+
 
 class IntEnum(enum.IntEnum):
     def translate(self, _escape_table):

--- a/pol/db/tables.py
+++ b/pol/db/tables.py
@@ -31,6 +31,28 @@ from sqlalchemy.dialects.mysql import (
 from pol.compat import phpseralize
 from pol.compat.phpseralize import dict_to_list
 
+__all__ = ["ChiiCharacter",
+           "ChiiCrtCastIndex",
+           "ChiiCrtSubjectIndex",
+           "ChiiEpRevision",
+           "ChiiEpisode",
+           "ChiiMemberfield",
+           "ChiiMember",
+           "ChiiOauthAccessToken",
+           "ChiiPersonCollect",
+           "ChiiPersonCsIndex",
+           "ChiiPersonField",
+           "ChiiCharacterField",
+           "ChiiPerson",
+           "ChiiRevHistory",
+           "GzipPHPSerializedBlob",
+           "ChiiRevText",
+           "ChiiSubjectField",
+           "ChiiSubjectRelations",
+           "ChiiSubjectRevision",
+           "ChiiSubject",
+           "ChiiSubjectInterest"]
+
 Base = declarative_base()
 metadata = Base.metadata
 

--- a/pol/depends.py
+++ b/pol/depends.py
@@ -2,6 +2,8 @@ from starlette.requests import Request
 
 from pol.redis.json_cache import JSONRedis
 
+__all__ = ["get_redis", "get_db"]
+
 
 async def get_redis(request: Request) -> JSONRedis:
     """defined at app.startup"""

--- a/pol/http_cache/depends.py
+++ b/pol/http_cache/depends.py
@@ -1,5 +1,7 @@
 from starlette.requests import Request
 
+__all__ = ["CacheControl"]
+
 
 class CacheControl:
     """用于控制响应的 `Cache-Control`"""

--- a/pol/middlewares/http.py
+++ b/pol/middlewares/http.py
@@ -5,6 +5,8 @@ from starlette.requests import Request
 
 from pol import config
 
+__all__ = ["setup_http_middleware"]
+
 
 def setup_http_middleware(app: FastAPI):
     @app.middleware("http")

--- a/pol/models/subject.py
+++ b/pol/models/subject.py
@@ -3,6 +3,8 @@ from typing import Optional
 
 from pydantic import Field, BaseModel
 
+__all__ = ["Subject", "Ep"]
+
 
 class Subject(BaseModel):
     id: int

--- a/pol/models/user.py
+++ b/pol/models/user.py
@@ -4,6 +4,8 @@ from pydantic import BaseModel
 
 from pol.permission import Role, UserGroup
 
+__all__ = ["Avatar", "PublicUser", "User"]
+
 
 class Avatar(BaseModel):
     large: str

--- a/pol/redis/json_cache.py
+++ b/pol/redis/json_cache.py
@@ -5,6 +5,8 @@ from aioredis import Redis
 from pydantic import BaseModel, ValidationError
 from aioredis.client import KeyT, ExpiryT
 
+__all__ = ["JSONRedis"]
+
 T = TypeVar("T", bound=BaseModel)
 
 

--- a/pol/res.py
+++ b/pol/res.py
@@ -7,6 +7,13 @@ from starlette.requests import Request
 from starlette.responses import JSONResponse
 from starlette.datastructures import URL
 
+__all__ = ["ORJSONResponse",
+           "HTTPException",
+           "HTTPRedirect",
+           "response",
+           "ErrorDetail",
+           "not_found_exception"]
+
 
 class ORJSONResponse(JSONResponse):
     media_type = "application/json"

--- a/pol/router.py
+++ b/pol/router.py
@@ -11,6 +11,8 @@ from fastapi.exceptions import RequestValidationError
 from pol import res
 from pol.res import ORJSONResponse
 
+__all__ = ["ErrorCatchRoute"]
+
 
 class ErrorCatchRoute(APIRoute):
     """starlette不支持全局 catch `Exception`，只能用这种办法来捕获内部异常。"""

--- a/pol/server.py
+++ b/pol/server.py
@@ -17,6 +17,8 @@ from pol.router import ErrorCatchRoute
 from pol.middlewares.http import setup_http_middleware
 from pol.redis.json_cache import JSONRedis
 
+__all__ = ["handle_public_cache", "global_404", "startup", "shutdown", "openapi", "doc"]
+
 app = FastAPI(
     debug=config.DEBUG,
     title=config.APP_NAME,

--- a/pol/services/rev_service/character_rev.py
+++ b/pol/services/rev_service/character_rev.py
@@ -10,6 +10,8 @@ from pol.db.const import RevisionType
 from pol.db.tables import ChiiRevText, ChiiRevHistory
 from pol.services.rev_service.exception import RevisionNotFound
 
+__all__ = ["CharacterHistory", "CharacterHistoryDetail"]
+
 
 class CharacterHistory(BaseModel):
     id: int

--- a/pol/services/rev_service/ep_rev.py
+++ b/pol/services/rev_service/ep_rev.py
@@ -10,6 +10,8 @@ from pol.db.const import RevisionType
 from pol.db.tables import ChiiEpRevision, ChiiRevHistory
 from pol.services.rev_service.exception import RevisionNotFound
 
+__all__ = ["EpisodeHistory", "EpisodeHistoryDetail"]
+
 episode_rev_type_filters = ChiiRevHistory.rev_type.in_(RevisionType.episode_rev_types())
 
 

--- a/pol/services/rev_service/exception.py
+++ b/pol/services/rev_service/exception.py
@@ -1,5 +1,7 @@
 from pol.curd import NotFoundError
 
+__all__ = ["RevisionNotFound"]
+
 
 class RevisionNotFound(NotFoundError):
     pass

--- a/pol/services/rev_service/person_rev.py
+++ b/pol/services/rev_service/person_rev.py
@@ -10,6 +10,8 @@ from pol.db.const import RevisionType
 from pol.db.tables import ChiiRevText, ChiiRevHistory
 from pol.services.rev_service.exception import RevisionNotFound
 
+__all__ = ["PersonHistory", "PersonHistoryDetail"]
+
 person_rev_type_filters = ChiiRevHistory.rev_type.in_(RevisionType.person_rev_types())
 
 

--- a/pol/services/rev_service/subject_rev.py
+++ b/pol/services/rev_service/subject_rev.py
@@ -10,6 +10,8 @@ from pol.db.const import RevisionType
 from pol.db.tables import ChiiRevHistory, ChiiSubjectRevision
 from pol.services.rev_service.exception import RevisionNotFound
 
+__all__ = ["SubjectHistory", "SubjectHistoryDetail"]
+
 subject_rev_type_filters = ChiiRevHistory.rev_type.in_(RevisionType.subject_rev_types())
 
 

--- a/pol/services/subject_service.py
+++ b/pol/services/subject_service.py
@@ -10,6 +10,8 @@ from pol.db.tables import ChiiSubject
 from pol.models.subject import Subject
 from pol.curd.exceptions import NotFoundError
 
+__all__ = ["SubjectNotFound", "SubjectService"]
+
 
 class SubjectNotFound(NotFoundError):
     pass

--- a/pol/services/user_service.py
+++ b/pol/services/user_service.py
@@ -11,6 +11,8 @@ from pol.depends import get_db
 from pol.db.tables import ChiiMember, ChiiOauthAccessToken
 from pol.curd.exceptions import NotFoundError
 
+__all__ = ["UserNotFound", "UserService"]
+
 
 class UserNotFound(NotFoundError):
     pass

--- a/pol/wiki/parser.py
+++ b/pol/wiki/parser.py
@@ -20,6 +20,8 @@ assert wiki.info == [
 import dataclasses
 from typing import Any, Dict, List, Optional
 
+__all__ = ["Wiki", "WikiSyntaxError", "kv", "parse"]
+
 
 @dataclasses.dataclass
 class Wiki:

--- a/pol/wiki/parser_test.py
+++ b/pol/wiki/parser_test.py
@@ -5,6 +5,7 @@ import pytest
 from .parser import WikiSyntaxError, kv, parse
 
 
+
 def test_key_value():
     raw = """{{Infobox animanga/TVAnime
 |中文名= Code Geass 反叛的鲁路修R2

--- a/pol/wiki/parser_test.py
+++ b/pol/wiki/parser_test.py
@@ -5,7 +5,6 @@ import pytest
 from .parser import WikiSyntaxError, kv, parse
 
 
-
 def test_key_value():
     raw = """{{Infobox animanga/TVAnime
 |中文名= Code Geass 反叛的鲁路修R2

--- a/scripts/dev.py
+++ b/scripts/dev.py
@@ -1,5 +1,7 @@
 import uvicorn
 
+__all__ = ["main"]
+
 
 def main():
     uvicorn.run("pol.server:app", port=3000)

--- a/scripts/public_archive.py
+++ b/scripts/public_archive.py
@@ -24,6 +24,20 @@ from pol.db.tables import (
 )
 from pol.api.v0.utils import get_career
 
+__all__ = ["main",
+           "export_person_characters",
+           "export_subject_persons",
+           "export_subject_characters",
+           "export_persons",
+           "export_characters",
+           "export_subject_self_relation",
+           "export_subjects",
+           "export_episodes",
+           "chunk_ids",
+           "get_max_character_id",
+           "get_max_person_id",
+           "get_max_subject_id"]
+
 
 @logger.catch()
 def main():

--- a/tests/app/api_v0/test_auth.py
+++ b/tests/app/api_v0/test_auth.py
@@ -9,6 +9,12 @@ from pol import config
 from pol.models import User, Avatar
 from pol.permission import UserGroup
 
+__all__ = ["test_auth_200",
+           "test_auth_403",
+           "test_auth_403_wrong_token",
+           "test_auth_cached",
+           "test_auth_cache_ban_cache_fallback"]
+
 
 @pytest.mark.env("e2e", "database", "redis")
 def test_auth_200(client: TestClient, auth_header):

--- a/tests/app/api_v0/test_character.py
+++ b/tests/app/api_v0/test_character.py
@@ -6,6 +6,18 @@ from starlette.testclient import TestClient
 
 from pol.config import CACHE_KEY_PREFIX
 
+__all__ = ["test_character_not_found",
+           "test_character_not_valid",
+           "test_character_basic",
+           "test_character_locked",
+           "test_character_ban_404",
+           "test_character_cache",
+           "test_character_subjects",
+           "test_character_subjects_ban",
+           "test_character_redirect",
+           "test_character_lock",
+           "test_character_persons"]
+
 
 @pytest.mark.env("e2e", "database", "redis")
 def test_character_not_found(client: TestClient):

--- a/tests/app/api_v0/test_collection.py
+++ b/tests/app/api_v0/test_collection.py
@@ -4,6 +4,13 @@ from starlette.testclient import TestClient
 from pol.db.const import SubjectType, CollectionType
 from tests.fixtures.mock_db_record import MockUser
 
+__all__ = ["test_collection_not_found",
+           "test_collection_public",
+           "test_collection_private",
+           "test_collection_username",
+           "test_collection_filter_subject",
+           "test_collection_filter_type"]
+
 
 @pytest.mark.env("e2e", "database", "redis")
 def test_collection_not_found(client: TestClient):

--- a/tests/app/api_v0/test_ep.py
+++ b/tests/app/api_v0/test_ep.py
@@ -3,6 +3,24 @@ from starlette.testclient import TestClient
 
 from pol.db.const import EpType
 
+__all__ = ["test_episode_404",
+           "test_episode",
+           "test_episode_nsfw_subject_404",
+           "test_episode_nsfw_subject",
+           "test_episodes",
+           "test_episodes_offset_too_big",
+           "test_episodes_empty",
+           "test_episodes_404",
+           "test_episodes_nsfw_non_auth",
+           "test_episodes_nsfw_auth",
+           "test_episodes_offset",
+           "test_episodes_non_normal_offset",
+           "test_episodes_start_non_1",
+           "test_episodes_start_non_offset",
+           "test_episode_offset",
+           "test_episodes_ban",
+           "test_episode_ban"]
+
 
 @pytest.mark.env("e2e", "database", "redis")
 def test_episode_404(client: TestClient):

--- a/tests/app/api_v0/test_person.py
+++ b/tests/app/api_v0/test_person.py
@@ -6,6 +6,16 @@ from starlette.testclient import TestClient
 
 from pol.config import CACHE_KEY_PREFIX
 
+__all__ = ["test_person_not_found",
+           "test_person_not_valid",
+           "test_person_basic",
+           "test_person_ban_404",
+           "test_person_cache",
+           "test_person_subjects",
+           "test_person_redirect",
+           "test_person_lock",
+           "test_person_characters"]
+
 
 @pytest.mark.env("e2e", "database", "redis")
 def test_person_not_found(client: TestClient):

--- a/tests/app/api_v0/test_revision.py
+++ b/tests/app/api_v0/test_revision.py
@@ -5,6 +5,16 @@ from starlette.testclient import TestClient
 
 from tests.fixtures.mock_service import MockUserService
 
+__all__ = ["test_person_revision_basic",
+           "test_person_revision_not_found",
+           "test_character_revision_basic",
+           "test_character_revision_not_found",
+           "test_subject_revision_basic",
+           "test_subject_revision_not_found",
+           "test_subject_revision_amazon",
+           "test_episode_revision_basic",
+           "test_episode_revision_not_found"]
+
 person_revisions_api_prefix = "/v0/revisions/persons"
 
 

--- a/tests/app/api_v0/test_revisions.py
+++ b/tests/app/api_v0/test_revisions.py
@@ -5,6 +5,19 @@ from starlette.testclient import TestClient
 
 from tests.fixtures.mock_service import MockUserService
 
+__all__ = ["test_person_revisions_basic",
+           "test_person_revisions_offset",
+           "test_person_revisions_offset_limit",
+           "test_character_revisions_basic",
+           "test_character_revisions_offset",
+           "test_character_revisions_page_limit",
+           "test_subject_revisions_basic",
+           "test_subject_revisions_offset",
+           "test_subject_revisions_page_limit",
+           "test_episode_revisions_basic",
+           "test_episode_revisions_offset",
+           "test_episode_revisions_page_limit"]
+
 person_revisions_api_prefix = "/v0/revisions/persons"
 
 

--- a/tests/app/api_v0/test_subject.py
+++ b/tests/app/api_v0/test_subject.py
@@ -19,6 +19,24 @@ from pol.api.v0.depends.auth import Guest
 from tests.fixtures.mock_redis import MockRedis
 from pol.services.subject_service import SubjectService
 
+__all__ = ["test_subject_not_found",
+           "test_subject_not_valid",
+           "test_subject_basic",
+           "test_subject_nsfw_auth_200",
+           "test_subject_redirect",
+           "test_subject_empty_image",
+           "test_subject_ep_query_limit_offset",
+           "test_subject_ep_type",
+           "test_subject_characters",
+           "test_subject_persons",
+           "test_subject_subjects_ban",
+           "test_subject_subjects",
+           "test_subject_cache_broken_purge",
+           "test_subject_tags",
+           "test_subject_tags_empty",
+           "test_subject_tags_none",
+           "test_subject_cache_header_public"]
+
 fixtures_path = Path(__file__).parent.joinpath("fixtures")
 
 

--- a/tests/app/api_v0/test_subject_auth.py
+++ b/tests/app/api_v0/test_subject_auth.py
@@ -5,6 +5,11 @@ from starlette.testclient import TestClient
 
 from pol import config
 
+__all__ = ["test_subject_auth_nsfw_no_auth_404",
+           "test_subject_auth_nsfw",
+           "test_subject_auth_cached",
+           "test_subject_nsfw_no_cache"]
+
 
 @pytest.mark.env("e2e", "database", "redis")
 def test_subject_auth_nsfw_no_auth_404(client: TestClient):

--- a/tests/app/services/test_subject_service.py
+++ b/tests/app/services/test_subject_service.py
@@ -5,6 +5,8 @@ from tests.base import async_test
 from pol.db.tables import ChiiSubject, ChiiSubjectField
 from pol.services.subject_service import SubjectService
 
+__all__ = ["test_get_by_id", "test_get_basic"]
+
 
 @pytest.mark.env("database")
 @async_test

--- a/tests/app/test_auth_deps.py
+++ b/tests/app/test_auth_deps.py
@@ -7,6 +7,8 @@ from tests.base import async_test
 from pol.api.v0.depends.auth import get_current_user
 from pol.services.user_service import UserService
 
+__all__ = ["test_depends_get_current_user"]
+
 
 @async_test
 async def test_depends_get_current_user(mock_redis):

--- a/tests/app/test_base_router.py
+++ b/tests/app/test_base_router.py
@@ -1,5 +1,7 @@
 from starlette.testclient import TestClient
 
+__all__ = ["test_doc_html", "test_doc_html_2", "test_openapi_json", "test_default_404"]
+
 
 def test_doc_html(client: TestClient):
     response = client.get("/v0", allow_redirects=False)

--- a/tests/app/test_redis.py
+++ b/tests/app/test_redis.py
@@ -5,6 +5,8 @@ from pol import config
 from tests.base import async_test
 from pol.redis.json_cache import JSONRedis
 
+__all__ = ["test_redis_util"]
+
 
 @pytest.mark.env("redis")
 @async_test

--- a/tests/app/test_user_service.py
+++ b/tests/app/test_user_service.py
@@ -9,6 +9,8 @@ from pol.db.tables import ChiiMember
 from pol.services.user_service import UserService
 from tests.fixtures.mock_db_record import MockUser
 
+__all__ = ["test_auth_expired_token", "test_auth_missing_user"]
+
 
 @pytest.mark.env("database")
 @async_test

--- a/tests/base.py
+++ b/tests/base.py
@@ -2,6 +2,8 @@ import asyncio
 import inspect
 from functools import wraps
 
+__all__ = ["async_test", "async_lambda"]
+
 
 def async_test(f):
     if not inspect.iscoroutinefunction(f):  # pragma: no cover

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,14 @@ from starlette.testclient import TestClient
 
 import pol.server
 
+__all__ = ["pytest_addoption",
+           "pytest_configure",
+           "pytest_runtest_setup",
+           "app",
+           "client",
+           "access_token",
+           "auth_header"]
+
 # mockers
 pytest_plugins = [
     "tests.fixtures.mock_redis",

--- a/tests/fixtures/mock_db.py
+++ b/tests/fixtures/mock_db.py
@@ -12,6 +12,8 @@ from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from pol import config
 from pol.depends import get_db
 
+__all__ = ["MockAsyncSession", "mock_db", "AsyncSessionMaker"]
+
 
 class MockAsyncSession(Protocol):
     get: mock.AsyncMock

--- a/tests/fixtures/mock_db_record.py
+++ b/tests/fixtures/mock_db_record.py
@@ -23,6 +23,14 @@ from pol.db.tables import (
     ChiiOauthAccessToken,
 )
 
+__all__ = ["db_session",
+           "mock_subject",
+           "mock_person",
+           "MockUser",
+           "mock_user",
+           "mock_user_collection",
+           "check_exist"]
+
 DBSession = sa.sync_session_maker()
 
 

--- a/tests/fixtures/mock_redis.py
+++ b/tests/fixtures/mock_redis.py
@@ -8,6 +8,8 @@ import pytest
 from pol import config
 from pol.depends import get_redis
 
+__all__ = ["MockRedis", "mock_redis", "redis_client"]
+
 
 class MockRedis(Protocol):
     get: mock.AsyncMock

--- a/tests/fixtures/mock_service.py
+++ b/tests/fixtures/mock_service.py
@@ -7,6 +7,8 @@ from fastapi import FastAPI
 from pol.models import Avatar, PublicUser
 from pol.services.user_service import UserService
 
+__all__ = ["MockUserService", "mock_user_service"]
+
 
 class MockUserService:
     async def get_users_by_id(self, ids: Iterator[int]) -> Dict[int, PublicUser]:


### PR DESCRIPTION
use tool (https://github.com/xwu64/python-auto-all) to generate`__all__` for python files. This tool go through all python files and ignores file, class and function with prefix "_". 
In this commit, I manually remove `__all__` for test files. 