### PR TITLE
fix: use `ORJSONResponse` directly from fastapi

### DIFF
--- a/pol/res.py
+++ b/pol/res.py
@@ -1,18 +1,9 @@
 from typing import Any, Dict, Type, Union, Optional
 from urllib.parse import quote
 
-import orjson
 from pydantic import Field, BaseModel
 from starlette.requests import Request
-from starlette.responses import JSONResponse
 from starlette.datastructures import URL
-
-
-class ORJSONResponse(JSONResponse):
-    media_type = "application/json"
-
-    def render(self, content: Any) -> bytes:
-        return orjson.dumps(content)
 
 
 class HTTPException(Exception):

--- a/pol/router.py
+++ b/pol/router.py
@@ -6,10 +6,10 @@ import sqlalchemy.exc
 from loguru import logger
 from fastapi import Request, Response
 from fastapi.routing import APIRoute
+from fastapi.responses import ORJSONResponse
 from fastapi.exceptions import RequestValidationError
 
 from pol import res
-from pol.res import ORJSONResponse
 
 
 class ErrorCatchRoute(APIRoute):

--- a/pol/server.py
+++ b/pol/server.py
@@ -5,14 +5,13 @@ import aioredis
 from loguru import logger
 from fastapi import FastAPI
 from sqlalchemy.orm import sessionmaker
-from fastapi.responses import HTMLResponse
+from fastapi.responses import HTMLResponse, ORJSONResponse
 from starlette.requests import Request
 from starlette.responses import Response
 from starlette.exceptions import HTTPException as StarletteHTTPException
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 
 from pol import api, config
-from pol.res import ORJSONResponse
 from pol.router import ErrorCatchRoute
 from pol.middlewares.http import setup_http_middleware
 from pol.redis.json_cache import JSONRedis


### PR DESCRIPTION
FastAPI 有在 `fastapi.responses` 里提供 `ORJSONResponse`，可以直接用，不用再自己定义一个了。如果是因为我不知道的特殊需求而使用自定义的 `ORJSONResponse` 可以直接 close PR

相关文档: https://fastapi.tiangolo.com/advanced/custom-response/#use-orjsonresponse