### PR TITLE
Fix some compatibility issues with openapi sdk generators.

### DIFF
--- a/web/spec.yaml
+++ b/web/spec.yaml
@@ -9,7 +9,7 @@ paths:
         - 条目
       summary: 获取条目
       description: cache with 300s
-      operationId: get_subject_by_id_v0_subjects__subject_id__get
+      operationId: getSubjectById
       parameters:
         - required: true
           schema:
@@ -44,7 +44,7 @@ paths:
       tags:
         - 条目
       summary: Get Subject Persons
-      operationId: get_subject_persons_v0_subjects__subject_id__persons_get
+      operationId: getRelatedPersonsBySubjectId
       parameters:
         - required: true
           schema:
@@ -84,7 +84,7 @@ paths:
       tags:
         - 条目
       summary: Get Subject Characters
-      operationId: get_subject_characters_v0_subjects__subject_id__characters_get
+      operationId: getRelatedCharactersBySubjectId
       parameters:
         - required: true
           schema:
@@ -124,7 +124,7 @@ paths:
       tags:
         - 条目
       summary: Get Subject Relations
-      operationId: get_subject_relations_v0_subjects__subject_id__subjects_get
+      operationId: getRelatedSubjectsBySubjectId
       parameters:
         - required: true
           schema:
@@ -164,7 +164,7 @@ paths:
       tags:
         - 章节
       summary: Get Episodes
-      operationId: get_episodes_v0_episodes_get
+      operationId: getEpisodes
       parameters:
         - required: true
           schema:
@@ -179,6 +179,7 @@ paths:
             allOf:
               - "$ref": "#/components/schemas/EpType"
             description: 参照章节的`type`
+            type: integer
           name: type
           in: query
         - required: false
@@ -224,7 +225,7 @@ paths:
       tags:
         - 章节
       summary: Get Episode
-      operationId: get_episode_v0_episodes__episode_id__get
+      operationId: getEpisodeById
       parameters:
         - required: true
           schema:
@@ -259,7 +260,7 @@ paths:
         - 角色
       summary: Get Character Detail
       description: cache with 60s
-      operationId: get_character_detail_v0_characters__character_id__get
+      operationId: getCharacterById
       parameters:
         - required: true
           schema:
@@ -292,7 +293,7 @@ paths:
       tags:
         - 角色
       summary: get character related subjects
-      operationId: get_person_subjects_v0_characters__character_id__subjects_get
+      operationId: getRelatedSubjectsByCharacterId
       parameters:
         - required: true
           schema:
@@ -330,7 +331,7 @@ paths:
       tags:
         - 角色
       summary: get character related persons
-      operationId: get_character_persons_v0_characters__character_id__persons_get
+      operationId: getRelatedPersonsByCharacterId
       parameters:
         - required: true
           schema:
@@ -369,7 +370,7 @@ paths:
         - 人物
       summary: Get Person
       description: cache with 60s
-      operationId: get_person_v0_persons__person_id__get
+      operationId: getPersonById
       parameters:
         - required: true
           schema:
@@ -402,7 +403,7 @@ paths:
       tags:
         - 人物
       summary: get person related subjects
-      operationId: get_person_subjects_v0_persons__person_id__subjects_get
+      operationId: getRelatedSubjectsByPersonId
       parameters:
         - required: true
           schema:
@@ -440,7 +441,7 @@ paths:
       tags:
         - 人物
       summary: get person related characters
-      operationId: get_person_characters_v0_persons__person_id__characters_get
+      operationId: getRelatedPersonsByPersonId
       parameters:
         - required: true
           schema:
@@ -479,7 +480,7 @@ paths:
         - 用户
       summary: Get User
       description: 返回当前 Access Token 对应的用户信息
-      operationId: get_user_v0_me_get
+      operationId: getUser
       responses:
         "200":
           description: Successful Response
@@ -501,7 +502,7 @@ paths:
         - 收藏
       summary: 获取用户收藏
       description: 获取对应用户的收藏，查看私有收藏需要access token。
-      operationId: get_user_collection_v0_users__username__collections_get
+      operationId: getUserCollectionsByUsername
       parameters:
         - description: 设置了 username 后无法使用UID
           required: true
@@ -523,6 +524,7 @@ paths:
               条目类型，默认为全部
 
               具体含义见 [SubjectType](#model-SubjectType)
+            type: integer
           name: subject_type
           in: query
         - description: |-
@@ -537,6 +539,7 @@ paths:
               收藏类型，默认为全部
 
               具体含义见 [CollectionType](#model-CollectionType)
+            type: integer
           name: type
           in: query
         - required: false
@@ -582,7 +585,7 @@ paths:
       tags:
         - 编辑历史
       summary: Get Person Revisions
-      operationId: get_person_revisions_v0_revisions_persons_get
+      operationId: getPersonRevisions
       parameters:
         - required: true
           schema:
@@ -626,7 +629,7 @@ paths:
       tags:
         - 编辑历史
       summary: Get Person Revision
-      operationId: get_person_revision_v0_revisions_persons__revision_id__get
+      operationId: getPersonRevisionByRevisionId
       parameters:
         - required: true
           schema:
@@ -659,7 +662,7 @@ paths:
       tags:
         - 编辑历史
       summary: Get Character Revisions
-      operationId: get_character_revisions_v0_revisions_characters_get
+      operationId: getCharacterRevisions
       parameters:
         - required: true
           schema:
@@ -703,7 +706,7 @@ paths:
       tags:
         - 编辑历史
       summary: Get Character Revision
-      operationId: get_character_revision_v0_revisions_characters__revision_id__get
+      operationId: getCharacterRevisionByRevisionId
       parameters:
         - required: true
           schema:
@@ -736,7 +739,7 @@ paths:
       tags:
         - 编辑历史
       summary: Get Subject Revisions
-      operationId: get_subject_revisions_v0_revisions_subjects_get
+      operationId: getSubjectRevisions
       parameters:
         - required: true
           schema:
@@ -780,7 +783,7 @@ paths:
       tags:
         - 编辑历史
       summary: Get Subject Revision
-      operationId: get_subject_revision_v0_revisions_subjects__revision_id__get
+      operationId: getSubjectRevisionByRevisionId
       parameters:
         - required: true
           schema:
@@ -813,7 +816,7 @@ paths:
       tags:
         - 编辑历史
       summary: Get Episode Revisions
-      operationId: get_episode_revisions_v0_revisions_episodes_get
+      operationId: getEpisodeRevisions
       parameters:
         - required: true
           schema:
@@ -857,7 +860,7 @@ paths:
       tags:
         - 编辑历史
       summary: Get Episode Revision
-      operationId: get_episode_revision_v0_revisions_episodes__revision_id__get
+      operationId: getEpisodeRevisionByRevisionId
       parameters:
         - required: true
           schema:
@@ -890,7 +893,7 @@ paths:
       tags:
         - 目录
       summary: Get Index By Id
-      operationId: get_index_by_id_v0_indices__index_id__get
+      operationId: getIndexById
       parameters:
         - required: true
           schema:
@@ -925,7 +928,7 @@ paths:
       tags:
         - 目录
       summary: Get Index Subjects
-      operationId: get_index_subjects_v0_indices__index_id__subjects_get
+      operationId: getIndexSubjectsByIndexId
       parameters:
         - required: true
           schema:
@@ -1023,11 +1026,13 @@ components:
           title: Name
           type: string
         type:
+          type: integer
           allOf:
             - "$ref": "#/components/schemas/CharacterType"
           description: 角色，机体，舰船，组织...
         images:
           title: Images
+          type: object
           allOf:
             - "$ref": "#/components/schemas/PersonImages"
           description: object with some size of images, this object maybe `null`
@@ -1050,6 +1055,7 @@ components:
           type: string
           description: parsed from wiki, maybe null
         blood_type:
+          type: integer
           allOf:
             - "$ref": "#/components/schemas/BloodType"
           description: parsed from wiki, maybe null, `1, 2, 3, 4` for `A, B, CD, O`
@@ -1085,11 +1091,13 @@ components:
           title: Name
           type: string
         type:
+          type: integer
           allOf:
             - "$ref": "#/components/schemas/CharacterType"
           description: 角色，机体，舰船，组织...
         images:
           title: Images
+          type: object
           allOf:
             - "$ref": "#/components/schemas/PersonImages"
           description: object with some size of images, this object maybe `null`
@@ -1191,6 +1199,7 @@ components:
           format: date-time
         data:
           title: Data
+          type: string
           description: 编辑修改内容
     PersonRevision:
       title: PersonRevision
@@ -1200,6 +1209,7 @@ components:
           properties:
             data:
               title: Data
+              type: object
               additionalProperties:
                 "$ref": "#/components/schemas/PersonRevisionDataItem"
     PersonRevisionDataItem:
@@ -1517,6 +1527,7 @@ components:
           default: 0
         stat:
           title: Stat
+          type: object
           allOf:
             - "$ref": "#/components/schemas/Stat"
           description: 目录评论及收藏数
@@ -1581,6 +1592,7 @@ components:
           type: string
         value:
           title: Value
+          type: object
           anyOf:
             - type: string
             - type: array
@@ -1739,6 +1751,7 @@ components:
           title: Name
           type: string
         type:
+          type: integer
           allOf:
             - "$ref": "#/components/schemas/PersonType"
           description: "`1`, `2`, `3` 表示 `个人`, `公司`, `组合`"
@@ -1748,6 +1761,7 @@ components:
             "$ref": "#/components/schemas/PersonCareer"
         images:
           title: Images
+          type: object
           allOf:
             - "$ref": "#/components/schemas/PersonImages"
           description: object with some size of images, this object maybe `null`
@@ -1787,6 +1801,7 @@ components:
           title: Name
           type: string
         type:
+          type: integer
           allOf:
             - "$ref": "#/components/schemas/CharacterType"
           description: 角色，机体，舰船，组织...
@@ -1824,6 +1839,7 @@ components:
           title: Name
           type: string
         type:
+          type: integer
           allOf:
             - "$ref": "#/components/schemas/PersonType"
           description: "`1`, `2`, `3` 表示 `个人`, `公司`, `组合`"
@@ -1833,6 +1849,7 @@ components:
             "$ref": "#/components/schemas/PersonCareer"
         images:
           title: Images
+          type: object
           allOf:
             - "$ref": "#/components/schemas/PersonImages"
           description: object with some size of images, this object maybe `null`
@@ -1862,6 +1879,7 @@ components:
           type: string
           description: parsed from wiki, maybe null
         blood_type:
+          type: integer
           allOf:
             - "$ref": "#/components/schemas/BloodType"
           description: parsed from wiki, maybe null, `1, 2, 3, 4` for `A, B, CD, O`
@@ -1966,11 +1984,13 @@ components:
           title: Name
           type: string
         type:
+          type: integer
           allOf:
             - "$ref": "#/components/schemas/CharacterType"
           description: 角色，机体，舰船，组织...
         images:
           title: Images
+          type: object
           allOf:
             - "$ref": "#/components/schemas/PersonImages"
           description: object with some size of images, this object maybe `null`
@@ -2001,6 +2021,7 @@ components:
           title: Name
           type: string
         type:
+          type: integer
           allOf:
             - "$ref": "#/components/schemas/PersonType"
           description: "`1`, `2`, `3` 表示 `个人`, `公司`, `组合`"
@@ -2010,6 +2031,7 @@ components:
             "$ref": "#/components/schemas/PersonCareer"
         images:
           title: Images
+          type: object
           allOf:
             - "$ref": "#/components/schemas/PersonImages"
           description: object with some size of images, this object maybe `null`


### PR DESCRIPTION
Fix some compatibility issues with OpenAPI SDK generators (e.g. Autorest needs to declare the type of a referenced model)

Change `operationId` to a more function-like name. since a lot of SDK generators use `operationId` as the generated function name.

