### PR TITLE
refactor: change variadic user getByIDs to slice

### DIFF
--- a/internal/ctrl/get_user.go
+++ b/internal/ctrl/get_user.go
@@ -60,7 +60,7 @@ func (ctl Ctrl) GetUser(ctx context.Context, userID model.UserID) (model.User, e
 	return r, nil
 }
 
-func (ctl Ctrl) GetUsersByIDs(ctx context.Context, userIDs ...model.UserID) (map[model.UserID]model.User, error) {
+func (ctl Ctrl) GetUsersByIDs(ctx context.Context, userIDs []model.UserID) (map[model.UserID]model.User, error) {
 	ctl.metricUserQueryCount.Inc(int64(len(userIDs)))
 	var notCached = make([]model.UserID, 0, len(userIDs))
 
@@ -81,7 +81,7 @@ func (ctl Ctrl) GetUsersByIDs(ctx context.Context, userIDs ...model.UserID) (map
 	}
 
 	ctl.metricUserQueryCached.Inc(int64(len(result)))
-	newUserMap, err := ctl.user.GetByIDs(ctx, notCached...)
+	newUserMap, err := ctl.user.GetByIDs(ctx, notCached)
 	if err != nil {
 		return nil, errgo.Wrap(err, "failed to get subjects")
 	}

--- a/internal/domain/user.go
+++ b/internal/domain/user.go
@@ -26,7 +26,7 @@ type UserRepo interface {
 	// GetByName find a user by username.
 	GetByName(ctx context.Context, username string) (model.User, error)
 
-	GetByIDs(ctx context.Context, ids ...model.UserID) (map[model.UserID]model.User, error)
+	GetByIDs(ctx context.Context, ids []model.UserID) (map[model.UserID]model.User, error)
 
 	GetFriends(ctx context.Context, userID model.UserID) (map[model.UserID]FriendItem, error)
 }

--- a/internal/mocks/UserRepo.go
+++ b/internal/mocks/UserRepo.go
@@ -51,8 +51,8 @@ type UserRepo_GetByID_Call struct {
 }
 
 // GetByID is a helper method to define mock.On call
-//   - ctx context.Context
-//   - userID model.UserID
+//  - ctx context.Context
+//  - userID model.UserID
 func (_e *UserRepo_Expecter) GetByID(ctx interface{}, userID interface{}) *UserRepo_GetByID_Call {
 	return &UserRepo_GetByID_Call{Call: _e.mock.On("GetByID", ctx, userID)}
 }
@@ -70,19 +70,12 @@ func (_c *UserRepo_GetByID_Call) Return(_a0 model.User, _a1 error) *UserRepo_Get
 }
 
 // GetByIDs provides a mock function with given fields: ctx, ids
-func (_m *UserRepo) GetByIDs(ctx context.Context, ids ...model.UserID) (map[model.UserID]model.User, error) {
-	_va := make([]interface{}, len(ids))
-	for _i := range ids {
-		_va[_i] = ids[_i]
-	}
-	var _ca []interface{}
-	_ca = append(_ca, ctx)
-	_ca = append(_ca, _va...)
-	ret := _m.Called(_ca...)
+func (_m *UserRepo) GetByIDs(ctx context.Context, ids []model.UserID) (map[model.UserID]model.User, error) {
+	ret := _m.Called(ctx, ids)
 
 	var r0 map[model.UserID]model.User
-	if rf, ok := ret.Get(0).(func(context.Context, ...model.UserID) map[model.UserID]model.User); ok {
-		r0 = rf(ctx, ids...)
+	if rf, ok := ret.Get(0).(func(context.Context, []model.UserID) map[model.UserID]model.User); ok {
+		r0 = rf(ctx, ids)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(map[model.UserID]model.User)
@@ -90,8 +83,8 @@ func (_m *UserRepo) GetByIDs(ctx context.Context, ids ...model.UserID) (map[mode
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, ...model.UserID) error); ok {
-		r1 = rf(ctx, ids...)
+	if rf, ok := ret.Get(1).(func(context.Context, []model.UserID) error); ok {
+		r1 = rf(ctx, ids)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -105,22 +98,15 @@ type UserRepo_GetByIDs_Call struct {
 }
 
 // GetByIDs is a helper method to define mock.On call
-//   - ctx context.Context
-//   - ids ...model.UserID
-func (_e *UserRepo_Expecter) GetByIDs(ctx interface{}, ids ...interface{}) *UserRepo_GetByIDs_Call {
-	return &UserRepo_GetByIDs_Call{Call: _e.mock.On("GetByIDs",
-		append([]interface{}{ctx}, ids...)...)}
+//  - ctx context.Context
+//  - ids []model.UserID
+func (_e *UserRepo_Expecter) GetByIDs(ctx interface{}, ids interface{}) *UserRepo_GetByIDs_Call {
+	return &UserRepo_GetByIDs_Call{Call: _e.mock.On("GetByIDs", ctx, ids)}
 }
 
-func (_c *UserRepo_GetByIDs_Call) Run(run func(ctx context.Context, ids ...model.UserID)) *UserRepo_GetByIDs_Call {
+func (_c *UserRepo_GetByIDs_Call) Run(run func(ctx context.Context, ids []model.UserID)) *UserRepo_GetByIDs_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		variadicArgs := make([]model.UserID, len(args)-1)
-		for i, a := range args[1:] {
-			if a != nil {
-				variadicArgs[i] = a.(model.UserID)
-			}
-		}
-		run(args[0].(context.Context), variadicArgs...)
+		run(args[0].(context.Context), args[1].([]model.UserID))
 	})
 	return _c
 }
@@ -157,8 +143,8 @@ type UserRepo_GetByName_Call struct {
 }
 
 // GetByName is a helper method to define mock.On call
-//   - ctx context.Context
-//   - username string
+//  - ctx context.Context
+//  - username string
 func (_e *UserRepo_Expecter) GetByName(ctx interface{}, username interface{}) *UserRepo_GetByName_Call {
 	return &UserRepo_GetByName_Call{Call: _e.mock.On("GetByName", ctx, username)}
 }
@@ -204,8 +190,8 @@ type UserRepo_GetFriends_Call struct {
 }
 
 // GetFriends is a helper method to define mock.On call
-//   - ctx context.Context
-//   - userID model.UserID
+//  - ctx context.Context
+//  - userID model.UserID
 func (_e *UserRepo_Expecter) GetFriends(ctx interface{}, userID interface{}) *UserRepo_GetFriends_Call {
 	return &UserRepo_GetFriends_Call{Call: _e.mock.On("GetFriends", ctx, userID)}
 }

--- a/internal/mocks/UserRepo.go
+++ b/internal/mocks/UserRepo.go
@@ -51,8 +51,8 @@ type UserRepo_GetByID_Call struct {
 }
 
 // GetByID is a helper method to define mock.On call
-//  - ctx context.Context
-//  - userID model.UserID
+//   - ctx context.Context
+//   - userID model.UserID
 func (_e *UserRepo_Expecter) GetByID(ctx interface{}, userID interface{}) *UserRepo_GetByID_Call {
 	return &UserRepo_GetByID_Call{Call: _e.mock.On("GetByID", ctx, userID)}
 }
@@ -98,8 +98,8 @@ type UserRepo_GetByIDs_Call struct {
 }
 
 // GetByIDs is a helper method to define mock.On call
-//  - ctx context.Context
-//  - ids []model.UserID
+//   - ctx context.Context
+//   - ids []model.UserID
 func (_e *UserRepo_Expecter) GetByIDs(ctx interface{}, ids interface{}) *UserRepo_GetByIDs_Call {
 	return &UserRepo_GetByIDs_Call{Call: _e.mock.On("GetByIDs", ctx, ids)}
 }
@@ -143,8 +143,8 @@ type UserRepo_GetByName_Call struct {
 }
 
 // GetByName is a helper method to define mock.On call
-//  - ctx context.Context
-//  - username string
+//   - ctx context.Context
+//   - username string
 func (_e *UserRepo_Expecter) GetByName(ctx interface{}, username interface{}) *UserRepo_GetByName_Call {
 	return &UserRepo_GetByName_Call{Call: _e.mock.On("GetByName", ctx, username)}
 }
@@ -190,8 +190,8 @@ type UserRepo_GetFriends_Call struct {
 }
 
 // GetFriends is a helper method to define mock.On call
-//  - ctx context.Context
-//  - userID model.UserID
+//   - ctx context.Context
+//   - userID model.UserID
 func (_e *UserRepo_Expecter) GetFriends(ctx interface{}, userID interface{}) *UserRepo_GetFriends_Call {
 	return &UserRepo_GetFriends_Call{Call: _e.mock.On("GetFriends", ctx, userID)}
 }

--- a/internal/pkg/test/web.go
+++ b/internal/pkg/test/web.go
@@ -200,13 +200,13 @@ func MockUserRepo(repo domain.UserRepo) fx.Option {
 		mocker := &mocks.UserRepo{}
 		mocker.EXPECT().GetByID(mock.Anything, mock.Anything).Return(model.User{}, nil)
 		mocker.On("GetByIDs", mock.Anything, mock.Anything).
-			Return(func(ctx context.Context, ids ...model.UserID) map[model.UserID]model.User {
+			Return(func(ctx context.Context, ids []model.UserID) map[model.UserID]model.User {
 				var ret = make(map[model.UserID]model.User, len(ids))
 				for _, id := range ids {
 					ret[id] = model.User{}
 				}
 				return ret
-			}, func(ctx context.Context, ids ...model.UserID) error {
+			}, func(ctx context.Context, ids []model.UserID) error {
 				return nil
 			})
 		repo = mocker

--- a/internal/user/mysql_repository.go
+++ b/internal/user/mysql_repository.go
@@ -67,7 +67,7 @@ func (m mysqlRepo) GetByName(ctx context.Context, username string) (model.User, 
 	return fromDao(u), nil
 }
 
-func (m mysqlRepo) GetByIDs(ctx context.Context, ids ...model.UserID) (map[model.UserID]model.User, error) {
+func (m mysqlRepo) GetByIDs(ctx context.Context, ids []model.UserID) (map[model.UserID]model.User, error) {
 	u, err := m.q.Member.WithContext(ctx).Where(m.q.Member.ID.In(slice.ToValuer(ids)...)).Find()
 	if err != nil {
 		m.log.Error("unexpected error happened", zap.Error(err))

--- a/internal/user/mysql_repository_test.go
+++ b/internal/user/mysql_repository_test.go
@@ -114,7 +114,7 @@ func TestMysqlRepo_GetByIDs(t *testing.T) {
 
 	repo := getRepo(t)
 
-	users, err := repo.GetByIDs(context.Background(), 1, 382951)
+	users, err := repo.GetByIDs(context.Background(), []model.UserID{1, 382951})
 	require.NoError(t, err)
 
 	require.Len(t, users, 2)

--- a/internal/web/handler/comments.go
+++ b/internal/web/handler/comments.go
@@ -202,7 +202,7 @@ func (h Handler) listComments(
 		return errgo.Wrap(err, "topic.ListReplies")
 	}
 
-	userMap, err := h.ctrl.GetUsersByIDs(c.Context(), commentsToUserIDs(comments)...)
+	userMap, err := h.ctrl.GetUsersByIDs(c.Context(), commentsToUserIDs(comments))
 	if err != nil {
 		return errgo.Wrap(err, "query.GetUsersByIDs")
 	}

--- a/internal/web/handler/group_private.go
+++ b/internal/web/handler/group_private.go
@@ -143,7 +143,7 @@ func (h Handler) listGroupMembers(
 	for i, member := range members {
 		userIDs[i] = member.UserID
 	}
-	userMap, err := h.ctrl.GetUsersByIDs(ctx, userIDs...)
+	userMap, err := h.ctrl.GetUsersByIDs(ctx, userIDs)
 	if err != nil {
 		return nil, errgo.Wrap(err, "userRepo.GetByIDs")
 	}

--- a/internal/web/handler/group_private_test.go
+++ b/internal/web/handler/group_private_test.go
@@ -36,7 +36,7 @@ func TestHandler_GetGroupByNamePrivate(t *testing.T) {
 	const gid = model.GroupID(5)
 
 	u := mocks.NewUserRepo(t)
-	u.EXPECT().GetByIDs(mock.Anything, model.UserID(3)).Return(map[model.UserID]model.User{
+	u.EXPECT().GetByIDs(mock.Anything, []model.UserID{3}).Return(map[model.UserID]model.User{
 		3: {UserName: "nn", ID: 1},
 	}, nil)
 
@@ -65,7 +65,7 @@ func TestHandler_ListGroupMembersPrivate(t *testing.T) {
 	const gid = model.GroupID(1)
 
 	u := mocks.NewUserRepo(t)
-	u.EXPECT().GetByIDs(mock.Anything, mock.Anything, mock.Anything).Return(map[model.UserID]model.User{
+	u.EXPECT().GetByIDs(mock.Anything, mock.Anything).Return(map[model.UserID]model.User{
 		1: {UserName: "nn", ID: 1},
 	}, nil)
 

--- a/internal/web/handler/revision.go
+++ b/internal/web/handler/revision.go
@@ -77,7 +77,7 @@ func (h Handler) listPersonRevision(c *fiber.Ctx, personID model.PersonID, page 
 		creatorIDs = append(creatorIDs, revision.CreatorID)
 	}
 
-	creatorMap, err := h.ctrl.GetUsersByIDs(c.Context(), slice.Unique(creatorIDs)...)
+	creatorMap, err := h.ctrl.GetUsersByIDs(c.Context(), slice.Unique(creatorIDs))
 	if err != nil {
 		return errgo.Wrap(err, "user.GetByIDs")
 	}
@@ -104,7 +104,7 @@ func (h Handler) GetPersonRevision(c *fiber.Ctx) error {
 		return errgo.Wrap(err, "failed to get person related revision")
 	}
 
-	creatorMap, err := h.ctrl.GetUsersByIDs(c.Context(), r.CreatorID)
+	creatorMap, err := h.ctrl.GetUsersByIDs(c.Context(), []model.UserID{r.CreatorID})
 	if err != nil {
 		return errgo.Wrap(err, "user.GetByIDs")
 	}
@@ -157,7 +157,7 @@ func (h Handler) listCharacterRevision(c *fiber.Ctx, characterID model.Character
 	for _, revision := range revisions {
 		creatorIDs = append(creatorIDs, revision.CreatorID)
 	}
-	creatorMap, err := h.ctrl.GetUsersByIDs(c.Context(), slice.Unique(creatorIDs)...)
+	creatorMap, err := h.ctrl.GetUsersByIDs(c.Context(), slice.Unique(creatorIDs))
 
 	if err != nil {
 		return errgo.Wrap(err, "user.GetByIDs")
@@ -188,7 +188,7 @@ func (h Handler) GetCharacterRevision(c *fiber.Ctx) error {
 		return errgo.Wrap(err, "failed to get character related revision")
 	}
 
-	creatorMap, err := h.ctrl.GetUsersByIDs(c.Context(), r.CreatorID)
+	creatorMap, err := h.ctrl.GetUsersByIDs(c.Context(), []model.UserID{r.CreatorID})
 	if err != nil {
 		return errgo.Wrap(err, "user.GetByIDs")
 	}
@@ -242,7 +242,7 @@ func (h Handler) listSubjectRevision(c *fiber.Ctx, subjectID model.SubjectID, pa
 	for _, revision := range revisions {
 		creatorIDs = append(creatorIDs, revision.CreatorID)
 	}
-	creatorMap, err := h.ctrl.GetUsersByIDs(c.Context(), slice.Unique(creatorIDs)...)
+	creatorMap, err := h.ctrl.GetUsersByIDs(c.Context(), slice.Unique(creatorIDs))
 
 	if err != nil {
 		return errgo.Wrap(err, "user.GetByIDs")
@@ -268,7 +268,7 @@ func (h Handler) GetSubjectRevision(c *fiber.Ctx) error {
 		return errgo.Wrap(err, "failed to get subject related revision")
 	}
 
-	creatorMap, err := h.ctrl.GetUsersByIDs(c.Context(), r.CreatorID)
+	creatorMap, err := h.ctrl.GetUsersByIDs(c.Context(), []model.UserID{r.CreatorID})
 	if err != nil {
 		return errgo.Wrap(err, "user.GetByIDs")
 	}

--- a/internal/web/handler/topic.go
+++ b/internal/web/handler/topic.go
@@ -56,7 +56,7 @@ func (h Handler) listTopics(c *fiber.Ctx, topicType domain.TopicType, id uint32)
 	userIDs := slice.Map(topics, func(item model.Topic) model.UserID {
 		return item.CreatorID
 	})
-	userMap, err := h.ctrl.GetUsersByIDs(c.Context(), slice.Unique(userIDs)...)
+	userMap, err := h.ctrl.GetUsersByIDs(c.Context(), slice.Unique(userIDs))
 	if err != nil {
 		return errgo.Wrap(err, "user.GetByIDs")
 	}
@@ -104,7 +104,7 @@ func (h Handler) getResTopicWithComments(
 
 	userIDs[t.CreatorID] = struct{}{}
 
-	users, err := h.ctrl.GetUsersByIDs(context.TODO(), gmap.Keys(userIDs)...)
+	users, err := h.ctrl.GetUsersByIDs(context.TODO(), gmap.Keys(userIDs))
 	if err != nil {
 		return nil, errgo.Wrap(err, "ctrl.GetUsersByIDs")
 	}


### PR DESCRIPTION
为了能让`mock`的`userRepo.getByIDs`可以支持任意数量`runtime`的`id`查询，把`ids`改为`slice`传入。