### PR TITLE
fix: limit 0 return nothing

### DIFF
--- a/ctrl/update_episode_progress.go
+++ b/ctrl/update_episode_progress.go
@@ -54,7 +54,7 @@ func (ctl Ctrl) UpdateEpisodesCollection(
 	/*
 		GORM v1.25.0 起修复了一个 bug，但是被当成 feature 使用了。在该版本之前，Limit 0 认为不是合法的 Limit，会被从 SQL 语句中忽略
 		see PR: go-gorm/gorm/pull/6191
-		因此这里需要传入 -1 作为 Limit，从而返回全部数据。GORM 会对负数过过滤，不会被当成 Limit。经过测试， SQL 也会对 -1 过滤
+		因此这里需要传入 -1 作为 Limit，从而返回全部数据。GORM 会对负数过过滤，不会出现在最终的 SQL 中。
 	*/
 	episodes, err := ctl.episode.List(ctx, subjectID, episode.Filter{}, -1, 0)
 	if err != nil {

--- a/ctrl/update_episode_progress.go
+++ b/ctrl/update_episode_progress.go
@@ -51,7 +51,12 @@ func (ctl Ctrl) UpdateEpisodesCollection(
 	ctl.log.Info("try to update collection info", zap.Uint32("subject", subjectID),
 		log.User(u.ID), zap.Reflect("episodes", episodeIDs))
 
-	episodes, err := ctl.episode.List(ctx, subjectID, episode.Filter{}, 0, 0)
+	/*
+		GORM v1.25.0 起修复了一个 bug，但是被当成 feature 使用了。在该版本之前，Limit 0 认为不是合法的 Limit，会被从 SQL 语句中忽略
+		see PR: go-gorm/gorm/pull/6191
+		因此这里需要传入 -1 作为 Limit，从而返回全部数据。GORM 会对负数过过滤，不会被当成 Limit。经过测试， SQL 也会对 -1 过滤
+	*/
+	episodes, err := ctl.episode.List(ctx, subjectID, episode.Filter{}, -1, 0)
 	if err != nil {
 		return errgo.Wrap(err, "episodeRepo.List")
 	}

--- a/internal/episode/mysql_repository.go
+++ b/internal/episode/mysql_repository.go
@@ -102,24 +102,7 @@ func (r mysqlRepo) List(
 
 	q = q.Order(r.q.Episode.Disc, r.q.Episode.Type, r.q.Episode.Sort)
 
-	/*
-		GORM v1.25.0 起修复了一个 bug，但是被当成 feature 使用了
-		see PR: https://github.com/go-gorm/gorm/pull/6191
-
-		在 v1.25.0 版本之前，Limit 0 认为不是合法的 Limit，会被从 SQL 语句中忽略
-
-		因此这里需要显性的对 Limit 判断
-	*/
-
-	if limit > 0 {
-		q = q.Limit(limit)
-	}
-
-	if offset > 0 {
-		q = q.Offset(offset)
-	}
-
-	episodes, err := q.Find()
+	episodes, err := q.Limit(limit).Offset(offset).Find()
 	if err != nil {
 		return nil, errgo.Wrap(err, "dal")
 	}

--- a/internal/episode/mysql_repository.go
+++ b/internal/episode/mysql_repository.go
@@ -100,9 +100,7 @@ func (r mysqlRepo) List(
 		q = q.Where(r.q.Episode.Type.Eq(filter.Type.Value))
 	}
 
-	q = q.Order(r.q.Episode.Disc, r.q.Episode.Type, r.q.Episode.Sort)
-
-	episodes, err := q.Limit(limit).Offset(offset).Find()
+	episodes, err := q.Order(r.q.Episode.Disc, r.q.Episode.Type, r.q.Episode.Sort).Limit(limit).Offset(offset).Find()
 	if err != nil {
 		return nil, errgo.Wrap(err, "dal")
 	}

--- a/internal/episode/mysql_repository.go
+++ b/internal/episode/mysql_repository.go
@@ -102,6 +102,15 @@ func (r mysqlRepo) List(
 
 	q = q.Order(r.q.Episode.Disc, r.q.Episode.Type, r.q.Episode.Sort)
 
+	/*
+		GORM v1.25.0 起修复了一个 bug，但是被当成 feature 使用了
+		see PR: https://github.com/go-gorm/gorm/pull/6191
+
+		在 v1.25.0 版本之前，Limit 0 认为不是合法的 Limit，会被从 SQL 语句中忽略
+
+		因此这里需要显性的对 Limit 判断
+	*/
+
 	if limit > 0 {
 		q = q.Limit(limit)
 	}

--- a/internal/episode/mysql_repository.go
+++ b/internal/episode/mysql_repository.go
@@ -100,7 +100,17 @@ func (r mysqlRepo) List(
 		q = q.Where(r.q.Episode.Type.Eq(filter.Type.Value))
 	}
 
-	episodes, err := q.Order(r.q.Episode.Disc, r.q.Episode.Type, r.q.Episode.Sort).Limit(limit).Offset(offset).Find()
+	q = q.Order(r.q.Episode.Disc, r.q.Episode.Type, r.q.Episode.Sort)
+
+	if limit > 0 {
+		q = q.Limit(limit)
+	}
+
+	if offset > 0 {
+		q = q.Offset(offset)
+	}
+
+	episodes, err := q.Find()
 	if err != nil {
 		return nil, errgo.Wrap(err, "dal")
 	}

--- a/internal/episode/mysql_repository_test.go
+++ b/internal/episode/mysql_repository_test.go
@@ -105,3 +105,20 @@ func TestMysqlRepo_List(t *testing.T) {
 		require.Len(t, episodes, tc.len)
 	}
 }
+
+func TestMysqlRepo_List_Empty_Return(t *testing.T) {
+	test.RequireEnv(t, test.EnvMysql)
+	t.Parallel()
+
+	repo := getRepo(t)
+
+	/*
+		GORM v1.25.0 起修复了一个 bug，但是被当成 feature 使用了
+		see PR: https://github.com/go-gorm/gorm/pull/6191
+
+		在 v1.25.0 版本之前，Limit 0 认为不适合合法的 Limit，会被从 SQL 语句中忽略
+	*/
+	episodes, err := repo.List(context.TODO(), 253, episode.Filter{}, 0, 0)
+	require.NoError(t, err)
+	require.Len(t, episodes, 0)
+}

--- a/internal/episode/mysql_repository_test.go
+++ b/internal/episode/mysql_repository_test.go
@@ -112,8 +112,8 @@ func TestMysqlRepo_List_Limit(t *testing.T) {
 
 	repo := getRepo(t)
 
-	nums := []int{0, 10, 22, 30, 100}
-	expected := []int{31, 10, 22, 30, 31}
+	nums := []int{-1, 0, 10, 22, 30, 100}
+	expected := []int{31, 0, 10, 22, 30, 31}
 
 	for i, num := range nums {
 		episodes, err := repo.List(context.TODO(), 253, episode.Filter{}, num, 0)

--- a/internal/episode/mysql_repository_test.go
+++ b/internal/episode/mysql_repository_test.go
@@ -105,20 +105,3 @@ func TestMysqlRepo_List(t *testing.T) {
 		require.Len(t, episodes, tc.len)
 	}
 }
-
-func TestMysqlRepo_List_Empty_Return(t *testing.T) {
-	test.RequireEnv(t, test.EnvMysql)
-	t.Parallel()
-
-	repo := getRepo(t)
-
-	/*
-		GORM v1.25.0 起修复了一个 bug，但是被当成 feature 使用了
-		see PR: https://github.com/go-gorm/gorm/pull/6191
-
-		在 v1.25.0 版本之前，Limit 0 认为不适合合法的 Limit，会被从 SQL 语句中忽略
-	*/
-	episodes, err := repo.List(context.TODO(), 253, episode.Filter{}, 0, 0)
-	require.NoError(t, err)
-	require.Len(t, episodes, 0)
-}

--- a/internal/episode/mysql_repository_test.go
+++ b/internal/episode/mysql_repository_test.go
@@ -105,3 +105,20 @@ func TestMysqlRepo_List(t *testing.T) {
 		require.Len(t, episodes, tc.len)
 	}
 }
+
+func TestMysqlRepo_List_Limit(t *testing.T) {
+	test.RequireEnv(t, test.EnvMysql)
+	t.Parallel()
+
+	repo := getRepo(t)
+
+	nums := []int{0, 10, 22, 30, 100}
+	expected := []int{31, 10, 22, 30, 31}
+
+	for i, num := range nums {
+		episodes, err := repo.List(context.TODO(), 253, episode.Filter{}, num, 0)
+		require.NoError(t, err)
+		require.Len(t, episodes, expected[i])
+	}
+
+}

--- a/internal/episode/mysql_repository_test.go
+++ b/internal/episode/mysql_repository_test.go
@@ -120,5 +120,4 @@ func TestMysqlRepo_List_Limit(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, episodes, expected[i])
 	}
-
 }


### PR DESCRIPTION
GORM v1.25.0 修复了一个 bug，但是在本项目被当成 feature 使用了。
在 v1.25.0 版本之前 （#335 做的更新），Limit 0 认为是不合法的 Limit，会被从 SQL 语句中忽略。
see PR: https://github.com/go-gorm/gorm/pull/6191

因此造成了 #346 #347 的问题
