### PR TITLE
docs(openapi): correct person image api tag

### DIFF
--- a/openapi/v0.yaml
+++ b/openapi/v0.yaml
@@ -602,7 +602,7 @@ paths:
   "/v0/persons/{person_id}/image":
     get:
       tags:
-        - 角色
+        - 人物
       summary: Get Person Image
       operationId: getPersonImageById
       parameters:


### PR DESCRIPTION
The current tag for the "[GET /v0/persons/{person_id}/image](https://bangumi.github.io/api/#/%E8%A7%92%E8%89%B2/getPersonImageById)" API in the v0.yaml file is incorrect.



![image](https://github.com/bangumi/server/assets/5327960/2cd99b1d-afab-4e7f-b901-c32c020702b8)
