### PR TITLE
feat: include field PrsnAppearEps in subject persons response

### DIFF
--- a/domain/relation.go
+++ b/domain/relation.go
@@ -29,6 +29,7 @@ type SubjectPersonRelation struct {
 
 	PersonID  model.PersonID
 	SubjectID model.SubjectID
+	Eps       string
 }
 
 type SubjectCharacterRelation struct {

--- a/internal/model/relation.go
+++ b/internal/model/relation.go
@@ -24,6 +24,7 @@ type SubjectPersonRelation struct {
 	Person  Person
 	Subject Subject
 	TypeID  uint16
+	Eps     string
 }
 
 type SubjectCharacterRelation struct {

--- a/internal/person/mysql_repository.go
+++ b/internal/person/mysql_repository.go
@@ -68,6 +68,7 @@ func (r mysqlRepo) GetSubjectRelated(
 		rel[i] = domain.SubjectPersonRelation{
 			PersonID: relation.PersonID,
 			TypeID:   relation.PrsnPosition,
+			Eps:      relation.PrsnAppearEps,
 		}
 	}
 

--- a/internal/person/service.go
+++ b/internal/person/service.go
@@ -65,6 +65,7 @@ func (s service) GetSubjectRelated(
 			Person:  persons[rel.PersonID],
 			Subject: sub,
 			TypeID:  rel.TypeID,
+			Eps:     rel.Eps,
 		}
 	}
 

--- a/openapi/v0.yaml
+++ b/openapi/v0.yaml
@@ -2961,6 +2961,7 @@ components:
         - type
         - career
         - relation
+        - eps
       type: object
       properties:
         id:
@@ -2987,6 +2988,10 @@ components:
         relation:
           title: Relation
           type: string
+        eps:
+          title: Eps
+          type: string
+          description: 参与章节/曲目
     UserCharacterCollection:
       title: UserCharacterCollection
       required:

--- a/web/handler/subject/related_persons.go
+++ b/web/handler/subject/related_persons.go
@@ -62,6 +62,7 @@ func (h Subject) GetRelatedPersons(c echo.Context) error {
 			Career:   rel.Person.Careers(),
 			Type:     rel.Person.Type,
 			ID:       rel.Person.ID,
+			Eps:      rel.Eps,
 		}
 	}
 

--- a/web/res/subject.go
+++ b/web/res/subject.go
@@ -198,6 +198,7 @@ type SubjectRelatedPerson struct {
 	Career   []string       `json:"career"`
 	Type     uint8          `json:"type"`
 	ID       model.PersonID `json:"id" doc:"person ID"`
+	Eps      string         `json:"eps" doc:"episodes participated"`
 }
 
 type Actor struct {


### PR DESCRIPTION
在条目-人物关联信息中返回参与章节。这个字段已经在 ORM 里了，这里只是将其暴露给 API 接口。命名有待讨论，暂定为`eps`