### PR TITLE
fix: remove redundant type definition for query parameters in OpenAPI spec

### DIFF
--- a/openapi/v0.yaml
+++ b/openapi/v0.yaml
@@ -505,7 +505,6 @@ paths:
             allOf:
               - "$ref": "#/components/schemas/EpType"
             description: 参照章节的`type`
-            type: integer
           name: type
           in: query
         - required: false
@@ -1092,7 +1091,6 @@ paths:
           schema:
             allOf:
               - "$ref": "#/components/schemas/SubjectCollectionType"
-            type: integer
           name: type
           in: query
         - $ref: "#/components/parameters/default_query_limit"


### PR DESCRIPTION
https://github.com/bangumi/api/issues/237