### PR TITLE
fix: remove duplicate values in the export

### DIFF
--- a/cmd/archive/main.go
+++ b/cmd/archive/main.go
@@ -364,10 +364,6 @@ func careers(p *dao.Person) []string {
 		s = append(s, "seiyu")
 	}
 
-	if p.Writer {
-		s = append(s, "writer")
-	}
-
 	if p.Illustrator {
 		s = append(s, "illustrator")
 	}


### PR DESCRIPTION
注意到归档数据中，人物职业字段存在重复的"writer"值

<img width="1833" height="377" alt="图片" src="https://github.com/user-attachments/assets/6c5ba73c-9d82-4120-9f75-35a702402d8e" />
