### PR TITLE
fix(openapi): add missing 0 to EpisodeCollectionType enum

### DIFF
--- a/openapi/components/episode_collection_type.yaml
+++ b/openapi/components/episode_collection_type.yaml
@@ -1,6 +1,7 @@
 title: EpisodeCollectionType
 example: 2
 enum:
+  - 0
   - 1
   - 2
   - 3
@@ -14,10 +15,12 @@ x-ms-enum:
   name: EpisodeCollectionType
   modelAsString: false
   values:
+    - None
     - Wish
     - Done
     - Dropped
 x-enum-varNames:
+  - None
   - Wish
   - Done
   - Dropped


### PR DESCRIPTION
The description documents `0` (未收藏) but the enum only listed `1, 2, 3`. This adds `0` to the enum, `x-ms-enum.values`, and `x-enum-varNames` to match the Go source where EpisodeCollectionNone = 0.

Fixes #1065