### PR TITLE
feat(archive): filter out banned/redirected subjects, persons and characters

### DIFF
--- a/cmd/archive/main.go
+++ b/cmd/archive/main.go
@@ -225,6 +225,10 @@ func exportSubjects(q *query.Query, w io.Writer) {
 		}
 
 		for _, subject := range subjects {
+			if subject.Fields.Redirect != 0 {
+				continue
+			}
+
 			tags, err := subjectDto.ParseTags(subject.Fields.Tags)
 			if err != nil {
 				tags = []model.Tag{}
@@ -332,7 +336,8 @@ type Person struct {
 func exportPersons(q *query.Query, w io.Writer) {
 	for i := model.PersonID(0); i < maxPersonID; i += defaultStep {
 		persons, err := q.WithContext(context.Background()).Person.
-			Where(q.Person.ID.Gt(i), q.Person.ID.Lte(i+defaultStep)).Find()
+			Where(q.Person.ID.Gt(i), q.Person.ID.Lte(i+defaultStep),
+				q.Person.Ban.Eq(0), q.Person.Redirect.Eq(0)).Find()
 		if err != nil {
 			panic(err)
 		}
@@ -403,7 +408,8 @@ type Character struct {
 func exportCharacters(q *query.Query, w io.Writer) {
 	for i := model.CharacterID(0); i < maxCharacterID; i += defaultStep {
 		characters, err := q.WithContext(context.Background()).Character.
-			Where(q.Character.ID.Gt(i), q.Character.ID.Lte(i+defaultStep)).Find()
+			Where(q.Character.ID.Gt(i), q.Character.ID.Lte(i+defaultStep),
+				q.Character.Ban.Eq(0), q.Character.Redirect.Eq(0)).Find()
 		if err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
## Summary

在 archive 导出中过滤掉被 ban 和 redirect 的条目：

- **Subjects**: SQL WHERE 中已有 `Ban.Eq(0)`，新增循环内跳过 `Fields.Redirect != 0`（因为 Redirect 在关联表 `chii_subject_fields` 上）
- **Persons**: SQL WHERE 中新增 `Ban.Eq(0)` 和 `Redirect.Eq(0)`
- **Characters**: SQL WHERE 中新增 `Ban.Eq(0)` 和 `Redirect.Eq(0)`

Closes https://github.com/bangumi/Archive/issues/25