### PR TITLE
fix(api): populate and document subject tag total count

### DIFF
--- a/openapi/components/subject_tags.yaml
+++ b/openapi/components/subject_tags.yaml
@@ -5,6 +5,7 @@ items:
   required:
     - name
     - count
+    - total_cont
   type: object
   properties:
     name:
@@ -12,4 +13,9 @@ items:
       type: string
     count:
       title: Count
+      description: 使用此标签标记本条目的用户数
+      type: integer
+    total_cont:
+      title: Total Count
+      description: 此标签在所有条目中的使用总次数
       type: integer

--- a/web/res/subject.go
+++ b/web/res/subject.go
@@ -93,8 +93,9 @@ func ToSlimSubjectV0(s model.Subject) SlimSubjectV0 {
 		Date:   date,
 		Tags: slice.Map(lo.Slice(s.Tags, 0, 10), func(item model.Tag) SubjectTag {
 			return SubjectTag{
-				Name:  item.Name,
-				Count: item.Count,
+				Name:      item.Name,
+				Count:     item.Count,
+				TotalCont: item.TotalCount,
 			}
 		}),
 		ShortSummary:    gstr.Slice(s.Summary, 0, defaultShortSummaryLength),
@@ -142,8 +143,9 @@ func ToSubjectV0(s model.Subject, totalEpisode int64, metaTags []tag.Tag) Subjec
 		}),
 		Tags: slice.Map(s.Tags, func(tag model.Tag) SubjectTag {
 			return SubjectTag{
-				Name:  tag.Name,
-				Count: tag.Count,
+				Name:      tag.Name,
+				Count:     tag.Count,
+				TotalCont: tag.TotalCount,
 			}
 		}),
 		Collection: SubjectCollectionStat{

--- a/web/res/subject_test.go
+++ b/web/res/subject_test.go
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package res_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/bangumi/server/internal/model"
+	"github.com/bangumi/server/web/res"
+)
+
+func TestToSubjectV0_TagTotalCount(t *testing.T) {
+	t.Parallel()
+
+	subject := model.Subject{
+		Tags: []model.Tag{{Name: "tag", Count: 10, TotalCount: 100}},
+	}
+	want := []res.SubjectTag{{Name: "tag", Count: 10, TotalCont: 100}}
+
+	require.Equal(t, want, res.ToSubjectV0(subject, 0, nil).Tags)
+}
+
+func TestToSlimSubjectV0_TagTotalCount(t *testing.T) {
+	t.Parallel()
+
+	subject := model.Subject{
+		Tags: []model.Tag{{Name: "tag", Count: 10, TotalCount: 100}},
+	}
+	want := []res.SubjectTag{{Name: "tag", Count: 10, TotalCont: 100}}
+
+	require.Equal(t, want, res.ToSlimSubjectV0(subject).Tags)
+}


### PR DESCRIPTION
## 背景

搜索接口已经正确填充条目标签的 `total_cont`，但 `ToSubjectV0` 和 `ToSlimSubjectV0` 转换时遗漏了该字段，导致相关接口始终将其序列化为 `0`。同时，OpenAPI 的 Tag schema 也没有声明该字段。

`total_cont` 中的 `cont` 疑似 `count` 的历史拼写错误。由于它已经是 v0 API 对外暴露的字段名，本 PR 为保持兼容继续沿用 `total_cont`，不做破坏性重命名。

## 修改内容

- 在 `ToSubjectV0` 中填充标签的总使用次数
- 在 `ToSlimSubjectV0` 中填充标签的总使用次数
- 在 OpenAPI Tag schema 中声明并说明 `total_cont`
- 为两个转换函数添加回归测试

## 测试

- `go test -tags test ./web/res/...`
- `yarn prettier --check openapi/components/subject_tags.yaml`
- `yarn run test`