### PR TITLE
fix(api)!: rename subject tag total_cont to total_count

### DIFF
--- a/internal/search/subject/handle.go
+++ b/internal/search/subject/handle.go
@@ -378,9 +378,9 @@ func toResponseSubject(s model.Subject, metaTags []tag.Tag) ResponseSubject {
 		}),
 		Tags: slice.Map(s.Tags, func(tag model.Tag) res.SubjectTag {
 			return res.SubjectTag{
-				Name:      tag.Name,
-				Count:     tag.Count,
-				TotalCont: tag.TotalCount,
+				Name:       tag.Name,
+				Count:      tag.Count,
+				TotalCount: tag.TotalCount,
 			}
 		}),
 		Collection: res.SubjectCollectionStat{

--- a/openapi/components/subject_tags.yaml
+++ b/openapi/components/subject_tags.yaml
@@ -5,7 +5,7 @@ items:
   required:
     - name
     - count
-    - total_cont
+    - total_count
   type: object
   properties:
     name:
@@ -15,7 +15,7 @@ items:
       title: Count
       description: 使用此标签标记本条目的用户数
       type: integer
-    total_cont:
+    total_count:
       title: Total Count
       description: 此标签在所有条目中的使用总次数
       type: integer

--- a/web/res/subject.go
+++ b/web/res/subject.go
@@ -36,9 +36,9 @@ const defaultShortSummaryLength = 120
 type V0wiki = []any
 
 type SubjectTag struct {
-	Name      string `json:"name"`
-	Count     uint   `json:"count"`
-	TotalCont uint   `json:"total_cont"`
+	Name       string `json:"name"`
+	Count      uint   `json:"count"`
+	TotalCount uint   `json:"total_count"`
 }
 
 type SubjectV0 struct {
@@ -93,9 +93,9 @@ func ToSlimSubjectV0(s model.Subject) SlimSubjectV0 {
 		Date:   date,
 		Tags: slice.Map(lo.Slice(s.Tags, 0, 10), func(item model.Tag) SubjectTag {
 			return SubjectTag{
-				Name:      item.Name,
-				Count:     item.Count,
-				TotalCont: item.TotalCount,
+				Name:       item.Name,
+				Count:      item.Count,
+				TotalCount: item.TotalCount,
 			}
 		}),
 		ShortSummary:    gstr.Slice(s.Summary, 0, defaultShortSummaryLength),
@@ -143,9 +143,9 @@ func ToSubjectV0(s model.Subject, totalEpisode int64, metaTags []tag.Tag) Subjec
 		}),
 		Tags: slice.Map(s.Tags, func(tag model.Tag) SubjectTag {
 			return SubjectTag{
-				Name:      tag.Name,
-				Count:     tag.Count,
-				TotalCont: tag.TotalCount,
+				Name:       tag.Name,
+				Count:      tag.Count,
+				TotalCount: tag.TotalCount,
 			}
 		}),
 		Collection: SubjectCollectionStat{

--- a/web/res/subject_test.go
+++ b/web/res/subject_test.go
@@ -17,6 +17,7 @@ package res_test
 import (
 	"testing"
 
+	"github.com/bytedance/sonic"
 	"github.com/stretchr/testify/require"
 
 	"github.com/bangumi/server/internal/model"
@@ -29,7 +30,7 @@ func TestToSubjectV0_TagTotalCount(t *testing.T) {
 	subject := model.Subject{
 		Tags: []model.Tag{{Name: "tag", Count: 10, TotalCount: 100}},
 	}
-	want := []res.SubjectTag{{Name: "tag", Count: 10, TotalCont: 100}}
+	want := []res.SubjectTag{{Name: "tag", Count: 10, TotalCount: 100}}
 
 	require.Equal(t, want, res.ToSubjectV0(subject, 0, nil).Tags)
 }
@@ -40,7 +41,16 @@ func TestToSlimSubjectV0_TagTotalCount(t *testing.T) {
 	subject := model.Subject{
 		Tags: []model.Tag{{Name: "tag", Count: 10, TotalCount: 100}},
 	}
-	want := []res.SubjectTag{{Name: "tag", Count: 10, TotalCont: 100}}
+	want := []res.SubjectTag{{Name: "tag", Count: 10, TotalCount: 100}}
 
 	require.Equal(t, want, res.ToSlimSubjectV0(subject).Tags)
+}
+
+func TestSubjectTag_JSON(t *testing.T) {
+	t.Parallel()
+
+	data, err := sonic.Marshal(res.SubjectTag{Name: "tag", Count: 10, TotalCount: 100})
+	require.NoError(t, err)
+	require.JSONEq(t, `{"name":"tag","count":10,"total_count":100}`, string(data))
+	require.NotContains(t, string(data), "total_cont")
 }


### PR DESCRIPTION
## 背景

#1124 补全并记录了标签总使用次数字段，但 `total_cont` 应为 `total_count`：领域模型和数据库映射均使用 `TotalCount`，只有 API 响应层存在该拼写错误。

当前提交直接将 `total_cont` 重命名为 `total_count`，不保留旧字段，因此属于破坏性变更。

由于 #1124 尚未部署，现在直接修正可以避免在更多接口中固化错误名称。想确认：

1. 是否接受直接重命名？
2. 还是应同时保留两个字段，将 `total_cont` 标记为 deprecated，后续再移除？
3. #1124 的接口改动和 API 文档预计何时发布？

## 修改内容

- 将 `TotalCont` / `total_cont` 重命名为 `TotalCount` / `total_count`
- 更新相关响应映射和 OpenAPI
- 增加 JSON 序列化测试

## 测试

- `go test -tags test ./web/res/... ./internal/search/subject/...`
- `yarn run test`